### PR TITLE
Handle sidebar click error

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -34,6 +34,42 @@ function App() {
           <Route path="/analytics" element={<Analytics />} />
           <Route path="/compliance" element={<Compliance />} />
           <Route path="/settings" element={<div className="p-6"><h1 className="text-2xl font-bold">Settings</h1><p>System settings coming soon...</p></div>} />
+          
+          {/* Customer sub-routes */}
+          <Route path="/customers/new" element={<div className="p-6"><h1 className="text-2xl font-bold">Add New Customer</h1><p>Add customer form coming soon...</p></div>} />
+          <Route path="/customers/kyc-pending" element={<div className="p-6"><h1 className="text-2xl font-bold">KYC Pending</h1><p>KYC pending customers coming soon...</p></div>} />
+          <Route path="/customers/risk" element={<div className="p-6"><h1 className="text-2xl font-bold">Risk Assessment</h1><p>Risk assessment coming soon...</p></div>} />
+          
+          {/* Account sub-routes */}
+          <Route path="/accounts/new" element={<div className="p-6"><h1 className="text-2xl font-bold">Open New Account</h1><p>Account opening form coming soon...</p></div>} />
+          <Route path="/accounts/blocked" element={<div className="p-6"><h1 className="text-2xl font-bold">Blocked Accounts</h1><p>Blocked accounts list coming soon...</p></div>} />
+          <Route path="/accounts/dormant" element={<div className="p-6"><h1 className="text-2xl font-bold">Dormant Accounts</h1><p>Dormant accounts list coming soon...</p></div>} />
+          
+          {/* Transaction sub-routes */}
+          <Route path="/transactions/pending" element={<div className="p-6"><h1 className="text-2xl font-bold">Pending Transactions</h1><p>Pending approvals coming soon...</p></div>} />
+          <Route path="/transactions/failed" element={<div className="p-6"><h1 className="text-2xl font-bold">Failed Transactions</h1><p>Failed transactions list coming soon...</p></div>} />
+          <Route path="/transactions/bulk" element={<div className="p-6"><h1 className="text-2xl font-bold">Bulk Upload</h1><p>Bulk transaction upload coming soon...</p></div>} />
+          
+          {/* Loan sub-routes */}
+          <Route path="/loans/applications" element={<div className="p-6"><h1 className="text-2xl font-bold">Loan Applications</h1><p>Loan applications coming soon...</p></div>} />
+          <Route path="/loans/disbursements" element={<div className="p-6"><h1 className="text-2xl font-bold">Loan Disbursements</h1><p>Disbursements coming soon...</p></div>} />
+          <Route path="/loans/collections" element={<div className="p-6"><h1 className="text-2xl font-bold">Loan Collections</h1><p>Collections coming soon...</p></div>} />
+          
+          {/* Report sub-routes */}
+          <Route path="/reports" element={<Reports />} />
+          <Route path="/reports/financial" element={<div className="p-6"><h1 className="text-2xl font-bold">Financial Reports</h1><p>Financial reports coming soon...</p></div>} />
+          <Route path="/reports/regulatory" element={<div className="p-6"><h1 className="text-2xl font-bold">Regulatory Reports</h1><p>Regulatory reports coming soon...</p></div>} />
+          <Route path="/reports/customers" element={<div className="p-6"><h1 className="text-2xl font-bold">Customer Reports</h1><p>Customer reports coming soon...</p></div>} />
+          <Route path="/reports/risk" element={<div className="p-6"><h1 className="text-2xl font-bold">Risk Reports</h1><p>Risk reports coming soon...</p></div>} />
+          
+          {/* Operations sub-routes */}
+          <Route path="/operations/branches" element={<div className="p-6"><h1 className="text-2xl font-bold">Branch Management</h1><p>Branch management coming soon...</p></div>} />
+          <Route path="/operations/users" element={<div className="p-6"><h1 className="text-2xl font-bold">User Management</h1><p>User management coming soon...</p></div>} />
+          <Route path="/operations/audit" element={<div className="p-6"><h1 className="text-2xl font-bold">Audit Trail</h1><p>Audit trail coming soon...</p></div>} />
+          <Route path="/operations/health" element={<div className="p-6"><h1 className="text-2xl font-bold">System Health</h1><p>System health monitoring coming soon...</p></div>} />
+          
+          {/* Help route */}
+          <Route path="/help" element={<div className="p-6"><h1 className="text-2xl font-bold">Help & Support</h1><p>Help documentation and support coming soon...</p></div>} />
           </Routes>
         </Layout>
       </Router>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -126,7 +126,7 @@ function NavItem({ item, level = 0 }) {
               isActive && "bg-accent text-accent-foreground"
             )}
           >
-            <item.icon className="h-4 w-4" />
+            {item.icon && <item.icon className="h-4 w-4" />}
             <span className="flex-1 text-left">{item.title}</span>
             {isOpen ? (
               <ChevronDown className="h-4 w-4" />
@@ -155,7 +155,7 @@ function NavItem({ item, level = 0 }) {
       asChild
     >
       <Link to={item.href}>
-        <item.icon className="h-4 w-4" />
+        {item.icon && <item.icon className="h-4 w-4" />}
         <span>{item.title}</span>
       </Link>
     </Button>
@@ -176,13 +176,17 @@ export function Sidebar() {
       {/* Footer */}
       <div className="border-t p-4">
         <div className="space-y-1">
-          <Button variant="ghost" className="w-full justify-start gap-2 font-normal">
-            <Settings className="h-4 w-4" />
-            <span>Settings</span>
+          <Button variant="ghost" className="w-full justify-start gap-2 font-normal" asChild>
+            <Link to="/settings">
+              <Settings className="h-4 w-4" />
+              <span>Settings</span>
+            </Link>
           </Button>
-          <Button variant="ghost" className="w-full justify-start gap-2 font-normal">
-            <HelpCircle className="h-4 w-4" />
-            <span>Help & Support</span>
+          <Button variant="ghost" className="w-full justify-start gap-2 font-normal" asChild>
+            <Link to="/help">
+              <HelpCircle className="h-4 w-4" />
+              <span>Help & Support</span>
+            </Link>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
Fix React error #130 and enable full sidebar navigation by conditionally rendering icons and adding missing routes.

The React error #130 (invalid element type) was triggered when `NavItem` attempted to render `item.icon` for navigation items that did not have an icon defined (e.g., child items). Additionally, many sidebar links pointed to routes that were not defined in `App.jsx`, preventing proper navigation. This PR addresses both by ensuring icons are only rendered when `item.icon` is present and by adding placeholder routes for all referenced sidebar links.

---

[Open in Web](https://www.cursor.com/agents?id=bc-c1715301-a1eb-4956-b3e9-4a4e4d75bc4c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-c1715301-a1eb-4956-b3e9-4a4e4d75bc4c)