### PR TITLE
Handle build error in vercel

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,0 +1,8 @@
+node_modules
+.git
+*.sql
+*.md
+docs
+.env*
+.DS_Store
+*.log

--- a/vercel.json
+++ b/vercel.json
@@ -1,17 +1,8 @@
 {
   "version": 2,
-  "builds": [
-    {
-      "src": "./index.html",
-      "use": "@vercel/static-build",
-      "config": { "distDir": "dist" }
-    }
-  ],
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
-    }
-  ]
+  "buildCommand": "pnpm build",
+  "outputDirectory": "dist",
+  "installCommand": "pnpm install",
+  "framework": "vite"
 }
 


### PR DESCRIPTION
Configure Vercel deployment for Vite project and add `.vercelignore` to fix build errors and optimize deployment.

The previous `vercel.json` configuration used `@vercel/static-build` with `index.html` as the source, which caused a Vercel build error because it expected a `package.json` or `build.sh` for a project requiring a build step. This PR updates `vercel.json` to correctly configure Vercel for a Vite project, using `pnpm` for installation and building, and sets the output directory to `dist`. Additionally, a `.vercelignore` file was added to exclude unnecessary files from deployment.

---

[Open in Web](https://www.cursor.com/agents?id=bc-17e7a085-1c66-4129-b641-06b5e4972abd) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-17e7a085-1c66-4129-b641-06b5e4972abd)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)