### PR TITLE
Debug react error 310

### DIFF
--- a/src/components/ui/ChartWidget.jsx
+++ b/src/components/ui/ChartWidget.jsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { cn } from '@/lib/utils';
+import { formatNumber } from '@/utils/formatters';
 import { 
   X,
   Settings,
@@ -150,7 +151,7 @@ export function ChartWidget({
   const defaultFormatters = {
     currency: (value) => `SAR ${(value / 1000000).toFixed(1)}M`,
     percentage: (value) => `${value}%`,
-    number: (value) => value.toLocaleString()
+          number: (value) => formatNumber(value)
   };
 
   const formatValue = formatTooltip || defaultFormatters.number;
@@ -357,7 +358,7 @@ export const CHART_PRESETS = {
   },
   transactions: {
     chartType: 'line',
-    formatTooltip: (value) => value.toLocaleString(),
+          formatTooltip: (value) => formatNumber(value),
     colors: ['#4A5568'],
     showGrid: true
   },

--- a/src/components/ui/ClientOnly.jsx
+++ b/src/components/ui/ClientOnly.jsx
@@ -1,0 +1,15 @@
+import { useHydrated } from '@/hooks/useHydrated';
+
+/**
+ * Component that only renders its children on the client side after hydration
+ * This prevents hydration mismatches for dynamic content like dates and locale-specific formatting
+ */
+export function ClientOnly({ children, fallback = null }) {
+  const hydrated = useHydrated();
+  
+  if (!hydrated) {
+    return fallback;
+  }
+  
+  return children;
+}

--- a/src/components/ui/chart.jsx
+++ b/src/components/ui/chart.jsx
@@ -2,6 +2,7 @@ import * as React from "react"
 import * as RechartsPrimitive from "recharts"
 
 import { cn } from "@/lib/utils"
+import { formatNumber } from "@/utils/formatters"
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = {
@@ -199,7 +200,7 @@ function ChartTooltipContent({
                     </div>
                     {item.value && (
                       <span className="text-foreground font-mono font-medium tabular-nums">
-                        {item.value.toLocaleString()}
+                        {formatNumber(item.value)}
                       </span>
                     )}
                   </div>

--- a/src/components/widgets/ComparisonWidget.jsx
+++ b/src/components/widgets/ComparisonWidget.jsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Badge } from '@/components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { formatNumber } from '@/utils/formatters';
 import {
   LineChart,
   Line,
@@ -105,8 +106,8 @@ export function ComparisonWidget({
                 <p className="text-sm text-muted-foreground">Current Month</p>
                 <p className="text-2xl font-bold">
                   {selectedMetric === 'revenue' && `SAR ${(comparisonMetrics.revenue.current / 1000000).toFixed(1)}M`}
-                  {selectedMetric === 'customers' && comparisonMetrics.customers.current.toLocaleString()}
-                  {selectedMetric === 'transactions' && comparisonMetrics.transactions.current.toLocaleString()}
+                  {selectedMetric === 'customers' && formatNumber(comparisonMetrics.customers.current)}
+                  {selectedMetric === 'transactions' && formatNumber(comparisonMetrics.transactions.current)}
                   {selectedMetric === 'deposits' && `SAR ${(comparisonMetrics.deposits.current / 1000000000).toFixed(1)}B`}
                 </p>
                 <div className="flex items-center gap-2">
@@ -129,8 +130,8 @@ export function ComparisonWidget({
                 <p className="text-sm text-muted-foreground">Previous Month</p>
                 <p className="text-2xl font-bold">
                   {selectedMetric === 'revenue' && `SAR ${(comparisonMetrics.revenue.previous / 1000000).toFixed(1)}M`}
-                  {selectedMetric === 'customers' && comparisonMetrics.customers.previous.toLocaleString()}
-                  {selectedMetric === 'transactions' && comparisonMetrics.transactions.previous.toLocaleString()}
+                  {selectedMetric === 'customers' && formatNumber(comparisonMetrics.customers.previous)}
+                  {selectedMetric === 'transactions' && formatNumber(comparisonMetrics.transactions.previous)}
                   {selectedMetric === 'deposits' && `SAR ${(comparisonMetrics.deposits.previous / 1000000000).toFixed(1)}B`}
                 </p>
               </div>
@@ -259,10 +260,10 @@ export function ComparisonWidget({
                 <p className="font-medium">{item.metric}</p>
                 <div className="flex items-center gap-4 mt-1">
                   <span className="text-sm text-muted-foreground">
-                    2024: {item.metric === 'Revenue' ? `SAR ${item.previous}M` : item.previous.toLocaleString()}
+                    2024: {item.metric === 'Revenue' ? `SAR ${item.previous}M` : formatNumber(item.previous)}
                   </span>
                   <span className="text-sm font-medium">
-                    2025: {item.metric === 'Revenue' ? `SAR ${item.current}M` : item.current.toLocaleString()}
+                    2025: {item.metric === 'Revenue' ? `SAR ${item.current}M` : formatNumber(item.current)}
                   </span>
                 </div>
               </div>

--- a/src/components/widgets/EnhancedChartWidget.jsx
+++ b/src/components/widgets/EnhancedChartWidget.jsx
@@ -4,6 +4,8 @@ import { useWidgetData } from '@/hooks/useWidgetData';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { formatNumber } from '@/utils/formatters';
+import { ClientOnly } from '@/components/ui/ClientOnly';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -89,7 +91,7 @@ const formatValue = (value, format) => {
         maximumFractionDigits: 1
       }).format(value);
     default:
-      return value.toLocaleString();
+      return formatNumber(value);
   }
 };
 
@@ -650,7 +652,7 @@ export function EnhancedChartWidget({
         <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground">
           <div className="flex items-center gap-4">
             {lastUpdated && (
-              <span>Updated {new Date(lastUpdated).toLocaleTimeString()}</span>
+                              <span>Updated <ClientOnly fallback="--:--:--">{new Date(lastUpdated).toLocaleTimeString('en-US')}</ClientOnly></span>
             )}
             {data && (
               <span>{data.length} data points</span>

--- a/src/components/widgets/EnhancedKPIWidget.jsx
+++ b/src/components/widgets/EnhancedKPIWidget.jsx
@@ -5,6 +5,8 @@ import { TrendingUp, TrendingDown, RefreshCw } from 'lucide-react';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Button } from '@/components/ui/button';
 import { ResponsiveContainer, LineChart, Line, Tooltip } from 'recharts';
+import { formatNumber } from '@/utils/formatters';
+import { ClientOnly } from '@/components/ui/ClientOnly';
 
 export function EnhancedKPIWidget({ widgetId, config, onConfigure }) {
   const { data, loading, error, lastUpdated, refetch } = useWidgetData(widgetId, config);
@@ -58,7 +60,7 @@ export function EnhancedKPIWidget({ widgetId, config, onConfigure }) {
           maximumFractionDigits: 1 
         }).format(value);
       default:
-        return `${config.prefix || ''}${value.toLocaleString()}${config.suffix || ''}`;
+        return `${config.prefix || ''}${formatNumber(value)}${config.suffix || ''}`;
     }
   };
 
@@ -161,7 +163,7 @@ export function EnhancedKPIWidget({ widgetId, config, onConfigure }) {
 
         {lastUpdated && (
           <p className="text-xs text-muted-foreground mt-3">
-            Updated {new Date(lastUpdated).toLocaleTimeString()}
+                          Updated <ClientOnly fallback="--:--:--">{new Date(lastUpdated).toLocaleTimeString('en-US')}</ClientOnly>
           </p>
         )}
       </CardContent>

--- a/src/components/widgets/KPIWidget.jsx
+++ b/src/components/widgets/KPIWidget.jsx
@@ -1,6 +1,7 @@
 import { BaseWidget } from './BaseWidget';
 import { ArrowUpRight, ArrowDownRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { formatNumber } from '@/utils/formatters';
 
 export function KPIWidget({
   id,
@@ -25,7 +26,7 @@ export function KPIWidget({
       if (val >= 1000) {
         return `${(val / 1000).toFixed(1)}K`;
       }
-      return val.toLocaleString();
+      return formatNumber(val);
     }
     return val;
   };

--- a/src/hooks/useHydrated.js
+++ b/src/hooks/useHydrated.js
@@ -1,0 +1,15 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Custom hook to detect when the app has been hydrated on the client
+ * This helps prevent hydration mismatches for dynamic content
+ */
+export function useHydrated() {
+  const [hydrated, setHydrated] = useState(false);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  return hydrated;
+}

--- a/src/pages/Accounts.jsx
+++ b/src/pages/Accounts.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import { formatNumber, formatCurrency as formatCurrencyUtil, formatDate } from '@/utils/formatters';
+import { ClientOnly } from '@/components/ui/ClientOnly';
 import { 
   CreditCard, 
   TrendingUp, 
@@ -204,7 +206,7 @@ export function Accounts() {
           .lt('created_at', nextMonth.toISOString());
 
         trends.push({
-          month: date.toLocaleDateString('en-US', { month: 'short' }),
+          month: formatDate(date, { month: 'short' }),
           accounts: count || 0
         });
       }
@@ -296,14 +298,14 @@ export function Accounts() {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <StatCard
           title="Total Accounts"
-          value={stats.totalAccounts.toLocaleString()}
+                            value={formatNumber(stats.totalAccounts)}
           icon={CreditCard}
           color="text-blue-500"
           trend={12}
         />
         <StatCard
           title="Active Accounts"
-          value={stats.activeAccounts.toLocaleString()}
+                      value={formatNumber(stats.activeAccounts)}
           icon={Activity}
           color="text-green-500"
           trend={8}
@@ -317,7 +319,7 @@ export function Accounts() {
         />
         <StatCard
           title="Blocked Accounts"
-          value={stats.blockedAccounts.toLocaleString()}
+                      value={formatNumber(stats.blockedAccounts)}
           icon={Lock}
           color="text-red-500"
           trend={-5}
@@ -493,7 +495,7 @@ export function Accounts() {
                             {account.account_type?.replace('_', ' ')}
                           </Badge>
                         </TableCell>
-                        <TableCell>SAR {parseFloat(account.current_balance).toLocaleString()}</TableCell>
+                                                      <TableCell>SAR {formatNumber(parseFloat(account.current_balance))}</TableCell>
                         <TableCell>
                           <Badge 
                             variant={
@@ -506,7 +508,7 @@ export function Accounts() {
                           </Badge>
                         </TableCell>
                         <TableCell>
-                          {new Date(account.created_at).toLocaleDateString()}
+                                                          <ClientOnly fallback="--/--/----">{formatDate(account.created_at)}</ClientOnly>
                         </TableCell>
                         <TableCell className="text-right">
                           <Button variant="ghost" size="sm">

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
+import { formatNumber, formatCurrency as formatCurrencyUtil, formatDate } from '@/utils/formatters';
 import { 
   TrendingUp,
   BarChart3,
@@ -152,7 +153,7 @@ export function Analytics() {
       date.setDate(date.getDate() - i);
       
       data.push({
-        date: date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+        date: formatDate(date, { month: 'short', day: 'numeric' }),
         revenue: Math.floor(Math.random() * 2000000) + 3000000,
         transactions: Math.floor(Math.random() * 5000) + 7000,
         newCustomers: Math.floor(Math.random() * 100) + 50,
@@ -269,7 +270,7 @@ export function Analytics() {
       ? `SAR ${(value / 1000000).toFixed(1)}M`
       : format === 'percent'
       ? `${value}%`
-      : value.toLocaleString();
+                      : formatNumber(value);
 
     return (
       <motion.div variants={itemVariants} whileHover={{ scale: 1.02 }}>
@@ -457,7 +458,7 @@ export function Analytics() {
                       <span className="text-sm">{segment.name}</span>
                     </div>
                     <div className="flex items-center gap-4">
-                      <span className="text-sm font-medium">{segment.value.toLocaleString()}</span>
+                                                    <span className="text-sm font-medium">{formatNumber(segment.value)}</span>
                       <Badge variant={segment.growth > 0 ? "success" : "destructive"}>
                         {segment.growth > 0 ? '+' : ''}{segment.growth}%
                       </Badge>
@@ -527,7 +528,7 @@ export function Analytics() {
                             ? `SAR ${(insight.predicted / 1000000).toFixed(0)}M`
                             : insight.metric.includes('%') || insight.metric.includes('Risk')
                             ? `${insight.predicted}%`
-                            : insight.predicted.toLocaleString()
+                                                            : formatNumber(insight.predicted)
                           }
                         </span>
                         <span className={`text-sm ${insight.trend === 'up' ? 'text-green-500' : 'text-red-500'}`}>

--- a/src/pages/Compliance.jsx
+++ b/src/pages/Compliance.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import { formatNumber, formatCurrency as formatCurrencyUtil, formatDate, formatDateTime } from '@/utils/formatters';
+import { ClientOnly } from '@/components/ui/ClientOnly';
 import { 
   Shield,
   AlertTriangle,
@@ -144,7 +146,7 @@ export function Compliance() {
         const date = new Date();
         date.setMonth(date.getMonth() - i);
         trends.push({
-          month: date.toLocaleDateString('en-US', { month: 'short' }),
+          month: formatDate(date, { month: 'short' }),
           overallScore: 85 + Math.random() * 10,
           amlScore: 88 + Math.random() * 10,
           kycScore: 82 + Math.random() * 10,
@@ -524,19 +526,19 @@ export function Compliance() {
               <div className="mt-4 grid grid-cols-2 gap-4">
                 <div className="flex items-center justify-between">
                   <span className="text-sm">Verified</span>
-                  <Badge variant="success">{kycStatus.verified.toLocaleString()}</Badge>
+                                                <Badge variant="success">{formatNumber(kycStatus.verified)}</Badge>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm">{t('common.pending')}</span>
-                  <Badge variant="warning">{kycStatus.pending.toLocaleString()}</Badge>
+                                      <Badge variant="warning">{formatNumber(kycStatus.pending)}</Badge>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm">Expired</span>
-                  <Badge variant="destructive">{kycStatus.expired.toLocaleString()}</Badge>
+                                      <Badge variant="destructive">{formatNumber(kycStatus.expired)}</Badge>
                 </div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm">Rejected</span>
-                  <Badge variant="destructive">{kycStatus.rejected.toLocaleString()}</Badge>
+                                      <Badge variant="destructive">{formatNumber(kycStatus.rejected)}</Badge>
                 </div>
               </div>
             </CardContent>
@@ -600,7 +602,7 @@ export function Compliance() {
                               {alert.severity}
                             </Badge>
                             <span className="text-xs text-muted-foreground">
-                              {new Date(alert.timestamp).toLocaleString()}
+                              <ClientOnly fallback="--/--/----">{formatDateTime(alert.timestamp)}</ClientOnly>
                             </span>
                           </div>
                         </div>
@@ -661,7 +663,7 @@ export function Compliance() {
                           <Progress value={assessment.score} className="w-20" />
                         </div>
                       </TableCell>
-                      <TableCell>{new Date(assessment.lastAssessment).toLocaleDateString()}</TableCell>
+                                                      <TableCell><ClientOnly fallback="--/--/----">{formatDate(assessment.lastAssessment)}</ClientOnly></TableCell>
                       <TableCell className="text-right">
                         <Button variant="ghost" size="sm">Review</Button>
                       </TableCell>
@@ -703,7 +705,7 @@ export function Compliance() {
                         <p className="font-medium">{entry.action}</p>
                         <p className="text-sm text-muted-foreground">{entry.details}</p>
                         <p className="text-xs text-muted-foreground mt-1">
-                          By {entry.user} • {new Date(entry.timestamp).toLocaleString()}
+                          By {entry.user} • <ClientOnly fallback="--/--/----">{formatDateTime(entry.timestamp)}</ClientOnly>
                         </p>
                       </div>
                     </div>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -1,6 +1,7 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
+import { formatNumber, formatCurrency as formatCurrencyUtil } from '@/utils/formatters';
 import { 
   Users, 
   CreditCard, 
@@ -74,7 +75,7 @@ function formatCurrency(amount, currency = 'SAR') {
   if (amount >= 1000) {
     return `${currency} ${(amount / 1000).toFixed(1)}K`;
   }
-  return `${currency} ${amount.toLocaleString()}`;
+  return `${currency} ${formatNumber(amount)}`;
 }
 
 function KPICard({ title, value, change, trend, icon: Icon, description, isLoading }) {
@@ -148,7 +149,7 @@ export function Dashboard() {
   const kpiData = [
     {
       title: t('dashboard.totalCustomers'),
-      value: displayKpis.total_customers?.toLocaleString() || '0',
+      value: displayKpis.total_customers ? formatNumber(displayKpis.total_customers) : '0',
       change: '+12.5%',
       trend: 'up',
       icon: Users,
@@ -156,7 +157,7 @@ export function Dashboard() {
     },
     {
       title: t('dashboard.activeAccounts'),
-      value: displayKpis.total_accounts?.toLocaleString() || '0',
+      value: displayKpis.total_accounts ? formatNumber(displayKpis.total_accounts) : '0',
       change: '+8.2%',
       trend: 'up',
       icon: CreditCard,
@@ -180,7 +181,7 @@ export function Dashboard() {
     },
     {
       title: 'Daily Transactions',
-      value: displayKpis.daily_transactions?.toLocaleString() || '0',
+      value: displayKpis.daily_transactions ? formatNumber(displayKpis.daily_transactions) : '0',
       change: '-2.4%',
       trend: 'down',
       icon: Activity,

--- a/src/pages/ExecutiveDashboard.jsx
+++ b/src/pages/ExecutiveDashboard.jsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ClientOnly } from '@/components/ui/ClientOnly';
+import { formatNumber, formatCurrency as formatCurrencyUtil } from '@/utils/formatters';
 import {
   LineChart,
   Line,
@@ -102,13 +103,13 @@ function formatCurrency(amount, currency = 'SAR') {
   if (amount >= 1000) {
     return `${currency} ${(amount / 1000).toFixed(1)}K`;
   }
-  return `${currency} ${amount.toLocaleString()}`;
+  return `${currency} ${formatNumber(amount)}`;
 }
 
 function KPICard({ title, value, change, trend, icon: Icon, description, format = 'number' }) {
   const formattedValue = format === 'currency' ? formatCurrency(value) : 
                         format === 'percentage' ? `${value}%` : 
-                        typeof value === 'number' ? value.toLocaleString() : value;
+                        typeof value === 'number' ? formatNumber(value) : value;
 
   return (
     <Card>

--- a/src/pages/ExecutiveDashboard.jsx
+++ b/src/pages/ExecutiveDashboard.jsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ClientOnly } from '@/components/ui/ClientOnly';
 import {
   LineChart,
   Line,
@@ -192,7 +193,7 @@ export function ExecutiveDashboard() {
         
         <div className="flex items-center space-x-2">
           <Badge variant="outline" className="text-xs">
-            Last updated: {lastUpdated.toLocaleTimeString()}
+            Last updated: <ClientOnly fallback="--:--:--">{lastUpdated.toLocaleTimeString()}</ClientOnly>
           </Badge>
           <Button variant="outline" size="sm" onClick={handleRefresh}>
             <RefreshCw className="mr-2 h-4 w-4" />

--- a/src/pages/Loans.jsx
+++ b/src/pages/Loans.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import { formatNumber, formatCurrency as formatCurrencyUtil, formatDate } from '@/utils/formatters';
+import { ClientOnly } from '@/components/ui/ClientOnly';
 import { 
   PiggyBank,
   TrendingUp, 
@@ -273,7 +275,7 @@ export function Loans() {
           .lt('created_at', nextMonth.toISOString());
 
         trends.push({
-          month: date.toLocaleDateString('en-US', { month: 'short' }),
+          month: formatDate(date, { month: 'short' }),
           disbursed: disbursed / 1000000, // Convert to millions
           applications: applications || 0
         });
@@ -391,7 +393,7 @@ export function Loans() {
         />
         <StatCard
           title="Active Loans"
-          value={stats.activeLoans.toLocaleString()}
+                      value={formatNumber(stats.activeLoans)}
           icon={PiggyBank}
           color="text-green-500"
           subtitle={`${stats.totalLoans} total loans`}
@@ -677,10 +679,10 @@ export function Loans() {
                               {LOAN_TYPES[loan.loan_type]?.label || loan.loan_type}
                             </Badge>
                           </TableCell>
-                          <TableCell>SAR {parseFloat(loan.loan_amount).toLocaleString()}</TableCell>
+                                                        <TableCell>SAR {formatNumber(parseFloat(loan.loan_amount))}</TableCell>
                           <TableCell>
                             <div>
-                              <div>SAR {parseFloat(loan.outstanding_balance).toLocaleString()}</div>
+                                                              <div>SAR {formatNumber(parseFloat(loan.outstanding_balance))}</div>
                               <Progress 
                                 value={((loan.loan_amount - loan.outstanding_balance) / loan.loan_amount) * 100} 
                                 className="w-20 h-2 mt-1"
@@ -696,9 +698,9 @@ export function Loans() {
                           <TableCell>
                             {nextPayment ? (
                               <div className={isOverdue ? 'text-red-500' : ''}>
-                                <div>{nextPayment.toLocaleDateString()}</div>
+                                                                  <div><ClientOnly fallback="--/--/----">{formatDate(nextPayment)}</ClientOnly></div>
                                 <div className="text-sm">
-                                  SAR {parseFloat(loan.monthly_payment || 0).toLocaleString()}
+                                  SAR {formatNumber(parseFloat(loan.monthly_payment || 0))}
                                 </div>
                               </div>
                             ) : (

--- a/src/pages/OperationsDashboard.jsx
+++ b/src/pages/OperationsDashboard.jsx
@@ -4,6 +4,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ClientOnly } from '@/components/ui/ClientOnly';
 import {
   LineChart,
   Line,

--- a/src/pages/OperationsDashboard.jsx
+++ b/src/pages/OperationsDashboard.jsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ClientOnly } from '@/components/ui/ClientOnly';
+import { formatNumber, formatCurrency as formatCurrencyUtil } from '@/utils/formatters';
 import {
   LineChart,
   Line,
@@ -122,14 +123,14 @@ function formatCurrency(amount, currency = 'SAR') {
   if (amount >= 1000) {
     return `${currency} ${(amount / 1000).toFixed(1)}K`;
   }
-  return `${currency} ${amount.toLocaleString()}`;
+  return `${currency} ${formatNumber(amount)}`;
 }
 
 function OperationalKPICard({ title, value, change, trend, icon: Icon, description, format = 'number', status }) {
   const formattedValue = format === 'currency' ? formatCurrency(value) : 
                         format === 'percentage' ? `${value}%` : 
                         format === 'time' ? `${value}s` :
-                        typeof value === 'number' ? value.toLocaleString() : value;
+                        typeof value === 'number' ? formatNumber(value) : value;
 
   const getStatusColor = () => {
     if (status === 'critical') return 'border-red-500 bg-red-50';

--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import { formatNumber, formatCurrency as formatCurrencyUtil, formatDate, formatDateTime } from '@/utils/formatters';
+import { ClientOnly } from '@/components/ui/ClientOnly';
 import { 
   FileText,
   Download,
@@ -242,7 +244,7 @@ export function Reports() {
         const date = new Date();
         date.setMonth(date.getMonth() - i);
         financialData.push({
-          month: date.toLocaleDateString('en-US', { month: 'short' }),
+          month: formatDate(date, { month: 'short' }),
           revenue: Math.floor(Math.random() * 50000000) + 100000000,
           expenses: Math.floor(Math.random() * 30000000) + 70000000,
           profit: Math.floor(Math.random() * 20000000) + 20000000
@@ -255,7 +257,7 @@ export function Reports() {
         const date = new Date();
         date.setDate(date.getDate() - i);
         customerData.push({
-          date: date.toLocaleDateString('en-US', { weekday: 'short' }),
+          date: formatDate(date, { weekday: 'short' }),
           new: Math.floor(Math.random() * 100) + 50,
           churned: Math.floor(Math.random() * 30) + 10,
           total: Math.floor(Math.random() * 1000) + 5000
@@ -545,7 +547,7 @@ export function Reports() {
                         </div>
                       </TableCell>
                       <TableCell>
-                        {new Date(report.generated_at).toLocaleString()}
+                                                        <ClientOnly fallback="--/--/----">{formatDateTime(report.generated_at)}</ClientOnly>
                       </TableCell>
                       <TableCell>{report.generated_by}</TableCell>
                       <TableCell>
@@ -624,7 +626,7 @@ export function Reports() {
                       </TableCell>
                       <TableCell>{report.schedule}</TableCell>
                       <TableCell>
-                        {new Date(report.next_run).toLocaleString()}
+                                                        <ClientOnly fallback="--/--/----">{formatDateTime(report.next_run)}</ClientOnly>
                       </TableCell>
                       <TableCell>
                         <div className="flex gap-1">

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useTranslation } from 'react-i18next';
+import { formatNumber, formatCurrency as formatCurrencyUtil, formatDate, formatTime } from '@/utils/formatters';
+import { ClientOnly } from '@/components/ui/ClientOnly';
 import { 
   ArrowUpDown,
   TrendingUp, 
@@ -280,7 +282,7 @@ export function Transactions() {
         const volume = volumeData?.reduce((sum, t) => sum + parseFloat(t.amount || 0), 0) || 0;
 
         trends.push({
-          date: date.toLocaleDateString('en-US', { weekday: 'short' }),
+          date: formatDate(date, { weekday: 'short' }),
           transactions: count || 0,
           volume: volume / 1000 // Convert to thousands
         });
@@ -404,7 +406,7 @@ export function Transactions() {
       <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
         <StatCard
           title="Total Transactions"
-          value={stats.totalTransactions.toLocaleString()}
+                            value={formatNumber(stats.totalTransactions)}
           icon={ArrowUpDown}
           color="text-blue-500"
           trend={8}
@@ -426,7 +428,7 @@ export function Transactions() {
         />
         <StatCard
           title={t('common.pending')}
-          value={stats.pendingTransactions.toLocaleString()}
+                            value={formatNumber(stats.pendingTransactions)}
           icon={Clock}
           color="text-yellow-500"
           subtitle={`Peak hour: ${stats.peakHour}`}
@@ -635,7 +637,7 @@ export function Transactions() {
                                 <TableCell>
                                   <div className={transaction.transaction_type === 'DEPOSIT' ? 'text-green-600' : 'text-red-600'}>
                                     {transaction.transaction_type === 'DEPOSIT' ? '+' : '-'}
-                                    SAR {parseFloat(transaction.amount).toLocaleString()}
+                                    SAR {formatNumber(parseFloat(transaction.amount))}
                                   </div>
                                 </TableCell>
                                 <TableCell>
@@ -645,12 +647,14 @@ export function Transactions() {
                                   </Badge>
                                 </TableCell>
                                 <TableCell>
-                                  <div>
-                                    <div>{new Date(transaction.transaction_date).toLocaleDateString()}</div>
-                                    <div className="text-sm text-muted-foreground">
-                                      {new Date(transaction.transaction_date).toLocaleTimeString()}
+                                  <ClientOnly fallback={<div>--/--/----</div>}>
+                                    <div>
+                                      <div>{formatDate(transaction.transaction_date)}</div>
+                                      <div className="text-sm text-muted-foreground">
+                                        {formatTime(transaction.transaction_date)}
+                                      </div>
                                     </div>
-                                  </div>
+                                  </ClientOnly>
                                 </TableCell>
                                 <TableCell className="text-right">
                                   <Button variant="ghost" size="sm">

--- a/src/utils/dateFormatting.js
+++ b/src/utils/dateFormatting.js
@@ -1,0 +1,54 @@
+/**
+ * Safe date formatting utilities that prevent hydration errors
+ * These functions ensure consistent date formatting between server and client
+ */
+
+/**
+ * Format a date to a locale string safely
+ * @param {Date|string} date - The date to format
+ * @param {string} locale - The locale to use (default: 'en-US')
+ * @param {object} options - Intl.DateTimeFormat options
+ * @returns {string} The formatted date string
+ */
+export function safeFormatDate(date, locale = 'en-US', options = {}) {
+  try {
+    const dateObj = typeof date === 'string' ? new Date(date) : date;
+    return dateObj.toLocaleDateString(locale, options);
+  } catch (error) {
+    console.error('Error formatting date:', error);
+    return '';
+  }
+}
+
+/**
+ * Format a time to a locale string safely
+ * @param {Date|string} date - The date/time to format
+ * @param {string} locale - The locale to use (default: 'en-US')
+ * @param {object} options - Intl.DateTimeFormat options
+ * @returns {string} The formatted time string
+ */
+export function safeFormatTime(date, locale = 'en-US', options = {}) {
+  try {
+    const dateObj = typeof date === 'string' ? new Date(date) : date;
+    return dateObj.toLocaleTimeString(locale, options);
+  } catch (error) {
+    console.error('Error formatting time:', error);
+    return '';
+  }
+}
+
+/**
+ * Format a number to a locale string safely
+ * @param {number} number - The number to format
+ * @param {string} locale - The locale to use (default: 'en-US')
+ * @param {object} options - Intl.NumberFormat options
+ * @returns {string} The formatted number string
+ */
+export function safeFormatNumber(number, locale = 'en-US', options = {}) {
+  try {
+    return number.toLocaleString(locale, options);
+  } catch (error) {
+    console.error('Error formatting number:', error);
+    return String(number);
+  }
+}

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,52 +1,111 @@
-import i18n from '@/i18n/i18n';
+/**
+ * Utility functions for consistent formatting across the application
+ * All formatting uses English (en-US) locale to ensure consistency
+ */
 
-export function formatNumber(number, options = {}) {
-  const locale = i18n.language === 'ar' ? 'ar-SA' : 'en-US';
-  return new Intl.NumberFormat(locale, options).format(number);
-}
-
-export function formatCurrency(amount, currency = 'SAR') {
-  const locale = i18n.language === 'ar' ? 'ar-SA' : 'en-US';
+/**
+ * Format a number to English locale string
+ * @param {number} value - The number to format
+ * @param {object} options - Intl.NumberFormat options
+ * @returns {string} The formatted number string
+ */
+export function formatNumber(value, options = {}) {
+  if (value === null || value === undefined) return '0';
   
-  return new Intl.NumberFormat(locale, {
-    style: 'currency',
-    currency: currency,
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 2,
-  }).format(amount);
+  try {
+    return new Intl.NumberFormat('en-US', options).format(value);
+  } catch (error) {
+    console.error('Error formatting number:', error);
+    return String(value);
+  }
 }
 
+/**
+ * Format currency in English locale
+ * @param {number} value - The amount to format
+ * @param {string} currency - The currency code (default: 'SAR')
+ * @returns {string} The formatted currency string
+ */
+export function formatCurrency(value, currency = 'SAR') {
+  if (value === null || value === undefined) return `${currency} 0`;
+  
+  try {
+    if (currency === 'SAR') {
+      // For SAR, use simple formatting without currency symbol from Intl
+      return `SAR ${formatNumber(value)}`;
+    }
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: currency,
+    }).format(value);
+  } catch (error) {
+    console.error('Error formatting currency:', error);
+    return `${currency} ${value}`;
+  }
+}
+
+/**
+ * Format a date to English locale string
+ * @param {Date|string} date - The date to format
+ * @param {object} options - Intl.DateTimeFormat options
+ * @returns {string} The formatted date string
+ */
 export function formatDate(date, options = {}) {
-  const locale = i18n.language === 'ar' ? 'ar-SA' : 'en-US';
+  if (!date) return '';
   
-  const defaultOptions = {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-    ...options
-  };
-  
-  return new Intl.DateTimeFormat(locale, defaultOptions).format(new Date(date));
+  try {
+    const dateObj = typeof date === 'string' ? new Date(date) : date;
+    return new Intl.DateTimeFormat('en-US', options).format(dateObj);
+  } catch (error) {
+    console.error('Error formatting date:', error);
+    return '';
+  }
 }
 
+/**
+ * Format a time to English locale string
+ * @param {Date|string} date - The date/time to format
+ * @param {object} options - Intl.DateTimeFormat options
+ * @returns {string} The formatted time string
+ */
 export function formatTime(date, options = {}) {
-  const locale = i18n.language === 'ar' ? 'ar-SA' : 'en-US';
+  if (!date) return '';
   
-  const defaultOptions = {
-    hour: '2-digit',
-    minute: '2-digit',
-    ...options
-  };
-  
-  return new Intl.DateTimeFormat(locale, defaultOptions).format(new Date(date));
+  try {
+    const dateObj = typeof date === 'string' ? new Date(date) : date;
+    return new Intl.DateTimeFormat('en-US', {
+      hour: 'numeric',
+      minute: 'numeric',
+      second: 'numeric',
+      ...options
+    }).format(dateObj);
+  } catch (error) {
+    console.error('Error formatting time:', error);
+    return '';
+  }
 }
 
-export function formatPercentage(value, decimals = 1) {
-  const locale = i18n.language === 'ar' ? 'ar-SA' : 'en-US';
+/**
+ * Format a date and time to English locale string
+ * @param {Date|string} date - The date/time to format
+ * @param {object} options - Intl.DateTimeFormat options
+ * @returns {string} The formatted date and time string
+ */
+export function formatDateTime(date, options = {}) {
+  if (!date) return '';
   
-  return new Intl.NumberFormat(locale, {
-    style: 'percent',
-    minimumFractionDigits: decimals,
-    maximumFractionDigits: decimals,
-  }).format(value / 100);
+  try {
+    const dateObj = typeof date === 'string' ? new Date(date) : date;
+    return new Intl.DateTimeFormat('en-US', {
+      year: 'numeric',
+      month: 'numeric',
+      day: 'numeric',
+      hour: 'numeric',
+      minute: 'numeric',
+      ...options
+    }).format(dateObj);
+  } catch (error) {
+    console.error('Error formatting datetime:', error);
+    return '';
+  }
 }


### PR DESCRIPTION
Standardize all number and date formatting to English (en-US) and resolve React hydration errors.

The initial problem was a React hydration error (#310) caused by locale-specific date/time formatting (`toLocaleDateString()`, `toLocaleTimeString()`) producing different outputs between server build and client render. This PR addresses that by introducing a `ClientOnly` wrapper for dynamic date/time displays. Additionally, it fulfills the request to format all numbers and dates consistently in English (en-US) by centralizing formatting logic in `src/utils/formatters.js` and applying it throughout the application.

---

[Open in Web](https://www.cursor.com/agents?id=bc-6afc6ddd-5efc-46f4-b848-55d5610e670d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6afc6ddd-5efc-46f4-b848-55d5610e670d)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)