### PR TITLE
Build and deploy osol_dashboards

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,16 +1,9 @@
 {
   "version": 2,
-  "builds": [
+  "rewrites": [
     {
-      "src": "./index.html",
-      "use": "@vercel/static-build",
-      "config": { "distDir": "dist" }
-    }
-  ],
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "/index.html"
+      "source": "/(.*)",
+      "destination": "/index.html"
     }
   ]
 }


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update Vercel configuration to fix build error for Vite project.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous `vercel.json` configuration explicitly used `@vercel/static-build` with `index.html` as the build source, which caused a build error as Vercel expected a `package.json` or `build.sh` for a typical application build. This PR removes the explicit `builds` configuration, allowing Vercel to auto-detect the Vite framework and its standard build process (e.g., `pnpm build` to `dist`). It also updates `routes` to the modern `rewrites` for client-side routing.

---

[Open in Web](https://www.cursor.com/agents?id=bc-f4a8b06a-7978-4d3e-a04d-81c5995cbd01) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-f4a8b06a-7978-4d3e-a04d-81c5995cbd01)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)