### PR TITLE
Fix ethereum property getter errors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,9 @@
-VITE_SUPABASE_URL=https://bzlenegoilnswsbanxgb.supabase.co
-VITE_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImJ6bGVuZWdvaWxuc3dzYmFueGdiIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTMyODU3ODIsImV4cCI6MjA2ODg2MTc4Mn0.DtVNndVsrUZtTtVRpEWiQb5QtbhPAErSQ88wWYVWeBE
+# Supabase Configuration
+VITE_SUPABASE_URL=your_supabase_project_url
+VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
+
+# Other environment variables
+# Add any other required environment variables here
 
 # Application Configuration
 VITE_APP_NAME=Osol Dashboard

--- a/provider-error-boundary.js
+++ b/provider-error-boundary.js
@@ -1,0 +1,70 @@
+// React Error Boundary for Provider Issues
+import React from 'react';
+
+class ProviderErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    // Update state so the next render will show the fallback UI
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // Log the error to an error reporting service
+    console.error('Provider Error:', error, errorInfo);
+    
+    // Check if it's a provider-related error
+    if (error.message?.includes('ethereum') || 
+        error.message?.includes('provider') ||
+        error.message?.includes('wallet')) {
+      console.warn('Wallet provider conflict detected. Please disable conflicting wallet extensions.');
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      // Fallback UI
+      return (
+        <div className="error-boundary">
+          <h2>Wallet Connection Issue</h2>
+          <p>We detected a conflict between multiple wallet extensions.</p>
+          <p>To fix this issue:</p>
+          <ol>
+            <li>Keep only one wallet extension enabled (preferably MetaMask)</li>
+            <li>Disable other wallet extensions temporarily</li>
+            <li>Refresh the page</li>
+          </ol>
+          <button onClick={() => window.location.reload()}>
+            Refresh Page
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+// Vue 3 Error Handler
+export function setupVueErrorHandler(app) {
+  app.config.errorHandler = (error, instance, info) => {
+    console.error('Vue Error:', error, info);
+    
+    // Check for provider-related errors
+    if (error.message?.includes('ethereum') || 
+        error.message?.includes('provider') ||
+        error.message?.includes('Cannot set property')) {
+      console.warn('Wallet provider conflict detected.');
+      
+      // Show user-friendly notification
+      if (window.alert) {
+        alert('Multiple wallet extensions detected. Please disable all except one and refresh the page.');
+      }
+    }
+  };
+}
+
+export default ProviderErrorBoundary;

--- a/wallet-integration-example.js
+++ b/wallet-integration-example.js
@@ -1,0 +1,120 @@
+// Example integration for your React/Vue app
+import { WalletProviderHandler } from './wallet-provider-handler.js';
+
+// Initialize wallet handler on app load
+let walletHandler;
+let currentProvider;
+
+async function initializeWalletConnection() {
+  try {
+    // Create handler instance
+    walletHandler = new WalletProviderHandler();
+    
+    // Wait for providers to be injected
+    await walletHandler.initialize();
+    
+    // Get available wallets
+    const availableWallets = walletHandler.listProviders();
+    console.log('Available wallet extensions:', availableWallets);
+    
+    // Check if we have any wallets
+    if (availableWallets.length === 0) {
+      console.warn('No wallet extensions detected. Please install MetaMask or another wallet.');
+      return null;
+    }
+    
+    // Prefer MetaMask if available
+    if (availableWallets.includes('metamask')) {
+      currentProvider = walletHandler.setPrimaryProvider('metamask');
+      console.log('Using MetaMask as primary wallet');
+    } else {
+      // Use first available wallet
+      currentProvider = walletHandler.getPrimaryProvider();
+      console.log('Using available wallet provider');
+    }
+    
+    // Set up event listeners
+    if (currentProvider) {
+      currentProvider.on('accountsChanged', handleAccountsChanged);
+      currentProvider.on('chainChanged', handleChainChanged);
+    }
+    
+    return currentProvider;
+  } catch (error) {
+    console.error('Failed to initialize wallet connection:', error);
+    return null;
+  }
+}
+
+// Handle account changes
+function handleAccountsChanged(accounts) {
+  console.log('Accounts changed:', accounts);
+  if (accounts.length === 0) {
+    // User disconnected wallet
+    console.log('Wallet disconnected');
+  } else {
+    // Update UI with new account
+    console.log('Active account:', accounts[0]);
+  }
+}
+
+// Handle chain changes
+function handleChainChanged(chainId) {
+  console.log('Chain changed to:', chainId);
+  // Reload the page or update app state
+  window.location.reload();
+}
+
+// Connect wallet function
+async function connectWallet() {
+  try {
+    if (!currentProvider) {
+      currentProvider = await initializeWalletConnection();
+      if (!currentProvider) {
+        throw new Error('No wallet provider available');
+      }
+    }
+    
+    // Request account access
+    const accounts = await currentProvider.request({ 
+      method: 'eth_requestAccounts' 
+    });
+    
+    console.log('Connected to wallet:', accounts[0]);
+    return accounts[0];
+  } catch (error) {
+    if (error.code === 4001) {
+      // User rejected request
+      console.log('User rejected wallet connection');
+    } else {
+      console.error('Failed to connect wallet:', error);
+    }
+    throw error;
+  }
+}
+
+// Disconnect wallet
+async function disconnectWallet() {
+  if (currentProvider) {
+    // Remove event listeners
+    currentProvider.removeListener('accountsChanged', handleAccountsChanged);
+    currentProvider.removeListener('chainChanged', handleChainChanged);
+    
+    // Some wallets support disconnect method
+    if (currentProvider.disconnect) {
+      await currentProvider.disconnect();
+    }
+    
+    currentProvider = null;
+    console.log('Wallet disconnected');
+  }
+}
+
+// Export functions for use in your app
+export {
+  initializeWalletConnection,
+  connectWallet,
+  disconnectWallet,
+  walletHandler,
+  currentProvider
+};

--- a/wallet-provider-handler.js
+++ b/wallet-provider-handler.js
@@ -1,0 +1,109 @@
+// Wallet Provider Handler
+// This module helps manage multiple wallet extensions gracefully
+
+class WalletProviderHandler {
+  constructor() {
+    this.providers = new Map();
+    this.primaryProvider = null;
+  }
+
+  // Initialize and detect available providers
+  async initialize() {
+    // Wait a bit for all providers to inject
+    await new Promise(resolve => setTimeout(resolve, 100));
+
+    // Check for different wallet providers
+    if (typeof window.ethereum !== 'undefined') {
+      // Handle MetaMask
+      if (window.ethereum.isMetaMask) {
+        this.providers.set('metamask', window.ethereum);
+      }
+      
+      // Handle multiple providers
+      if (window.ethereum.providers?.length > 0) {
+        window.ethereum.providers.forEach(provider => {
+          if (provider.isMetaMask) {
+            this.providers.set('metamask', provider);
+          } else if (provider.isCoinbaseWallet) {
+            this.providers.set('coinbase', provider);
+          } else if (provider.isTrust) {
+            this.providers.set('trust', provider);
+          }
+        });
+      }
+    }
+
+    // Check for other common providers
+    if (window.coinbaseWalletExtension) {
+      this.providers.set('coinbase', window.coinbaseWalletExtension);
+    }
+
+    return this.providers;
+  }
+
+  // Get a specific provider
+  getProvider(walletName) {
+    return this.providers.get(walletName);
+  }
+
+  // Set primary provider
+  setPrimaryProvider(walletName) {
+    const provider = this.providers.get(walletName);
+    if (provider) {
+      this.primaryProvider = provider;
+      return provider;
+    }
+    throw new Error(`Provider ${walletName} not found`);
+  }
+
+  // Get primary provider or first available
+  getPrimaryProvider() {
+    if (this.primaryProvider) {
+      return this.primaryProvider;
+    }
+    
+    // Return first available provider
+    const firstProvider = this.providers.values().next().value;
+    if (firstProvider) {
+      this.primaryProvider = firstProvider;
+      return firstProvider;
+    }
+    
+    throw new Error('No wallet provider found');
+  }
+
+  // List available providers
+  listProviders() {
+    return Array.from(this.providers.keys());
+  }
+}
+
+// Usage example:
+async function connectWallet() {
+  const walletHandler = new WalletProviderHandler();
+  
+  try {
+    await walletHandler.initialize();
+    const availableWallets = walletHandler.listProviders();
+    console.log('Available wallets:', availableWallets);
+    
+    // Use MetaMask if available, otherwise use first available
+    let provider;
+    if (availableWallets.includes('metamask')) {
+      provider = walletHandler.setPrimaryProvider('metamask');
+    } else {
+      provider = walletHandler.getPrimaryProvider();
+    }
+    
+    // Now use the provider
+    const accounts = await provider.request({ method: 'eth_requestAccounts' });
+    console.log('Connected accounts:', accounts);
+    
+    return provider;
+  } catch (error) {
+    console.error('Failed to connect wallet:', error);
+    throw error;
+  }
+}
+
+export { WalletProviderHandler, connectWallet };


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add wallet provider management and error handling to resolve `window.ethereum` conflicts from multiple browser extensions.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses `TypeError: Cannot set property ethereum of #<Window> which has only a getter` and `Cannot redefine property: ethereum` errors. These occur when multiple browser wallet extensions (like MetaMask, Coinbase Wallet, etc.) try to inject or redefine the `window.ethereum` object simultaneously. The new `WalletProviderHandler` class helps detect and manage these providers, allowing the application to select a primary one. A `ProviderErrorBoundary` is also introduced to provide user-friendly feedback when such conflicts arise. Additionally, the `.env.example` is updated to guide Supabase configuration.

---

[Open in Web](https://cursor.com/agents?id=bc-099f0a92-7f38-4c4b-acbc-e322fcf450d8) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-099f0a92-7f38-4c4b-acbc-e322fcf450d8)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)