### PR TITLE
Fix toast declaration error in compliance page

### DIFF
--- a/src/pages/Compliance.jsx
+++ b/src/pages/Compliance.jsx
@@ -34,7 +34,6 @@ import { Progress } from '@/components/ui/progress';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { supabase, TABLES } from '@/lib/supabase';
 import { ComparisonWidget } from '@/components/widgets/ComparisonWidget';
-import { toast } from 'sonner';
 import {
   Table,
   TableBody,


### PR DESCRIPTION
Remove duplicate 'toast' import to fix build error.

---

[Open in Web](https://cursor.com/agents?id=bc-867c74cf-daac-4bb9-9f5f-9a78819c4630) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-867c74cf-daac-4bb9-9f5f-9a78819c4630)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)