### PR TITLE
Fix toast declaration error in compliance page

### DIFF
--- a/src/pages/Compliance.jsx
+++ b/src/pages/Compliance.jsx
@@ -34,7 +34,6 @@ import { Progress } from '@/components/ui/progress';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { supabase, TABLES } from '@/lib/supabase';
 import { ComparisonWidget } from '@/components/widgets/ComparisonWidget';
-import { toast } from 'sonner';
 import {
   Table,
   TableBody,


### PR DESCRIPTION
Remove duplicate `toast` import from `Compliance.jsx` to resolve build failure.

The build was failing with "ERROR: The symbol "toast" has already been declared" due to `toast` being imported twice from 'sonner' in the file.

---

[Open in Web](https://cursor.com/agents?id=bc-7be164cf-d34f-4373-bca8-9233a5268004) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7be164cf-d34f-4373-bca8-9233a5268004)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)