### PR TITLE
Convert all numbers to English words

### DIFF
--- a/src/pages/CollectionCases.jsx
+++ b/src/pages/CollectionCases.jsx
@@ -132,7 +132,7 @@ const CollectionCases = () => {
   };
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -142,7 +142,7 @@ const CollectionCases = () => {
 
   const formatDate = (dateString) => {
     if (!dateString) return 'N/A';
-    return new Date(dateString).toLocaleDateString('ar-SA');
+    return new Date(dateString).toLocaleDateString('en-US');
   };
 
   const getStatusBadge = (status) => {

--- a/src/pages/CollectionOverview.jsx
+++ b/src/pages/CollectionOverview.jsx
@@ -46,7 +46,7 @@ const CollectionOverview = () => {
   };
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -55,7 +55,7 @@ const CollectionOverview = () => {
   };
 
   const formatNumber = (num) => {
-    return new Intl.NumberFormat('ar-SA').format(num);
+    return new Intl.NumberFormat('en-US').format(num);
   };
 
   const getStatusColor = (status) => {

--- a/src/pages/CollectionReports.jsx
+++ b/src/pages/CollectionReports.jsx
@@ -55,7 +55,7 @@ const CollectionReports = () => {
   };
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -64,7 +64,7 @@ const CollectionReports = () => {
   };
 
   const formatNumber = (num) => {
-    return new Intl.NumberFormat('ar-SA').format(num);
+    return new Intl.NumberFormat('en-US').format(num);
   };
 
   const formatPercentage = (value) => {

--- a/src/pages/DailyCollectionDashboard.tsx
+++ b/src/pages/DailyCollectionDashboard.tsx
@@ -126,7 +126,7 @@ const DailyCollectionDashboard = () => {
   };
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -135,10 +135,11 @@ const DailyCollectionDashboard = () => {
   };
 
   const formatTime = (date) => {
-    return date.toLocaleTimeString('ar-SA', { 
+    return date.toLocaleTimeString('en-US', { 
       hour: '2-digit', 
       minute: '2-digit', 
-      second: '2-digit' 
+      second: '2-digit',
+      hour12: false
     });
   };
 

--- a/src/pages/DelinquencyExecutiveDashboard.tsx
+++ b/src/pages/DelinquencyExecutiveDashboard.tsx
@@ -159,7 +159,7 @@ const DelinquencyExecutiveDashboard = () => {
 
   // تنسيق الأرقام
   const formatCurrency = (value) => {
-    return new Intl.NumberFormat(i18n.language === 'ar' ? 'ar-SA' : 'en-US', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -168,7 +168,7 @@ const DelinquencyExecutiveDashboard = () => {
   };
 
   const formatPercentage = (value) => {
-    return new Intl.NumberFormat(i18n.language === 'ar' ? 'ar-SA' : 'en-US', {
+    return new Intl.NumberFormat('en-US', {
       style: 'percent',
       minimumFractionDigits: 2,
       maximumFractionDigits: 2

--- a/src/pages/DigitalCollectionDashboard.tsx
+++ b/src/pages/DigitalCollectionDashboard.tsx
@@ -114,7 +114,7 @@ const DigitalCollectionDashboard = () => {
   };
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -123,7 +123,7 @@ const DigitalCollectionDashboard = () => {
   };
 
   const formatNumber = (num) => {
-    return new Intl.NumberFormat('ar-SA').format(num);
+    return new Intl.NumberFormat('en-US').format(num);
   };
 
   const getChannelColor = (channel) => {

--- a/src/pages/EarlyWarningDashboard.tsx
+++ b/src/pages/EarlyWarningDashboard.tsx
@@ -153,7 +153,7 @@ const EarlyWarningDashboard = () => {
   };
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -162,7 +162,7 @@ const EarlyWarningDashboard = () => {
   };
 
   const formatNumber = (num) => {
-    return new Intl.NumberFormat('ar-SA').format(num);
+    return new Intl.NumberFormat('en-US').format(num);
   };
 
   const getRiskColor = (level) => {

--- a/src/pages/ExecutiveCollectionDashboard.tsx
+++ b/src/pages/ExecutiveCollectionDashboard.tsx
@@ -132,7 +132,7 @@ const ExecutiveCollectionDashboard = () => {
   const COLORS = ['#E6B800', '#F4D03F', '#F7DC6F', '#F9E79F', '#FCF3CF'];
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -141,7 +141,7 @@ const ExecutiveCollectionDashboard = () => {
   };
 
   const formatNumber = (num) => {
-    return new Intl.NumberFormat('ar-SA').format(num);
+    return new Intl.NumberFormat('en-US').format(num);
   };
 
   const getPriorityBadge = (priority) => {

--- a/src/pages/FieldCollectionDashboard.tsx
+++ b/src/pages/FieldCollectionDashboard.tsx
@@ -228,7 +228,7 @@ const FieldCollectionDashboard = () => {
   };
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -237,7 +237,7 @@ const FieldCollectionDashboard = () => {
   };
 
   const formatNumber = (num) => {
-    return new Intl.NumberFormat('ar-SA').format(num);
+    return new Intl.NumberFormat('en-US').format(num);
   };
 
   const getStatusColor = (status) => {

--- a/src/pages/OfficerPerformanceDashboard.tsx
+++ b/src/pages/OfficerPerformanceDashboard.tsx
@@ -185,7 +185,7 @@ const OfficerPerformanceDashboard = () => {
   };
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -194,7 +194,7 @@ const OfficerPerformanceDashboard = () => {
   };
 
   const formatNumber = (num) => {
-    return new Intl.NumberFormat('ar-SA').format(num);
+    return new Intl.NumberFormat('en-US').format(num);
   };
 
   const getTrendIcon = (trend) => {

--- a/src/pages/ShariaComplianceDashboard.tsx
+++ b/src/pages/ShariaComplianceDashboard.tsx
@@ -118,7 +118,7 @@ const ShariaComplianceDashboard = () => {
   ];
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -128,7 +128,7 @@ const ShariaComplianceDashboard = () => {
 
   const formatDate = (dateString) => {
     if (!dateString) return 'Pending';
-    return new Date(dateString).toLocaleDateString('ar-SA');
+    return new Date(dateString).toLocaleDateString('en-US');
   };
 
   const getComplianceColor = (rate) => {

--- a/src/pages/VintageAnalysisDashboard.tsx
+++ b/src/pages/VintageAnalysisDashboard.tsx
@@ -118,7 +118,7 @@ const VintageAnalysisDashboard = () => {
   };
 
   const formatCurrency = (amount) => {
-    return new Intl.NumberFormat('ar-SA', {
+    return new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'SAR',
       minimumFractionDigits: 0,
@@ -127,7 +127,7 @@ const VintageAnalysisDashboard = () => {
   };
 
   const formatNumber = (num) => {
-    return new Intl.NumberFormat('ar-SA').format(num);
+    return new Intl.NumberFormat('en-US').format(num);
   };
 
   const getPerformanceColor = (value, type = 'default') => {

--- a/src/services/dashboardService.js
+++ b/src/services/dashboardService.js
@@ -173,7 +173,7 @@ export class DashboardService {
         status: tx.status || 'UNKNOWN',
         transaction_datetime: tx.transaction_date,
         description: tx.narration,
-        formatted_amount: new Intl.NumberFormat('ar-SA', {
+                  formatted_amount: new Intl.NumberFormat('en-US', {
           style: 'currency',
           currency: tx.currency_code || 'SAR'
         }).format(parseFloat(tx.transaction_amount) || 0)

--- a/src/utils/formatters.js
+++ b/src/utils/formatters.js
@@ -1,12 +1,14 @@
 import i18n from '@/i18n/i18n';
 
 export function formatNumber(number, options = {}) {
-  const locale = i18n.language === 'ar' ? 'ar-SA' : 'en-US';
+  // Always use English locale for numbers
+  const locale = 'en-US';
   return new Intl.NumberFormat(locale, options).format(number);
 }
 
 export function formatCurrency(amount, currency = 'SAR') {
-  const locale = i18n.language === 'ar' ? 'ar-SA' : 'en-US';
+  // Always use English locale for numbers
+  const locale = 'en-US';
   
   return new Intl.NumberFormat(locale, {
     style: 'currency',
@@ -42,7 +44,8 @@ export function formatTime(date, options = {}) {
 }
 
 export function formatPercentage(value, decimals = 1) {
-  const locale = i18n.language === 'ar' ? 'ar-SA' : 'en-US';
+  // Always use English locale for numbers
+  const locale = 'en-US';
   
   return new Intl.NumberFormat(locale, {
     style: 'percent',


### PR DESCRIPTION
Standardize all number and date formatting to English locale.

This ensures all numerical and date displays across the application, especially dashboards, consistently use English numerals (e.g., 1, 2, 3) instead of Arabic numerals (e.g., ١, ٢, ٣), regardless of the current i18n language setting.

---

[Open in Web](https://cursor.com/agents?id=bc-eff66243-f948-48fa-93c1-af3eddd083fe) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-eff66243-f948-48fa-93c1-af3eddd083fe)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)