### PR TITLE
Fix queries to use kastle_banking schema

### DIFF
--- a/src/pages/Accounts.jsx
+++ b/src/pages/Accounts.jsx
@@ -21,7 +21,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { supabase, TABLES } from '@/lib/supabase';
+import { supabaseBanking, TABLES } from '@/lib/supabase';
 import { ComparisonWidget } from '@/components/widgets/ComparisonWidget';
 import { toast } from 'sonner';
 import {
@@ -78,7 +78,7 @@ export function Accounts() {
   const fetchAccounts = async () => {
     try {
       setLoading(true);
-      let query = supabase
+      let query = supabaseBanking
         .from(TABLES.ACCOUNTS)
         .select(`
           *,
@@ -115,30 +115,30 @@ export function Accounts() {
   const fetchAccountStats = async () => {
     try {
       // Get total accounts count
-      const { count: totalAccounts } = await supabase
+      const { count: totalAccounts } = await supabaseBanking
         .from(TABLES.ACCOUNTS)
         .select('*', { count: 'exact', head: true });
 
       // Get active accounts
-      const { count: activeAccounts } = await supabase
+      const { count: activeAccounts } = await supabaseBanking
         .from(TABLES.ACCOUNTS)
         .select('*', { count: 'exact', head: true })
         .eq('account_status', 'ACTIVE');
 
       // Get blocked accounts
-      const { count: blockedAccounts } = await supabase
+      const { count: blockedAccounts } = await supabaseBanking
         .from(TABLES.ACCOUNTS)
         .select('*', { count: 'exact', head: true })
         .eq('account_status', 'BLOCKED');
 
       // Get dormant accounts
-      const { count: dormantAccounts } = await supabase
+      const { count: dormantAccounts } = await supabaseBanking
         .from(TABLES.ACCOUNTS)
         .select('*', { count: 'exact', head: true })
         .eq('account_status', 'DORMANT');
 
       // Get total balance
-      const { data: balanceData } = await supabase
+      const { data: balanceData } = await supabaseBanking
         .from(TABLES.ACCOUNTS)
         .select('current_balance')
         .eq('account_status', 'ACTIVE');
@@ -150,13 +150,13 @@ export function Accounts() {
       startOfMonth.setDate(1);
       startOfMonth.setHours(0, 0, 0, 0);
 
-      const { count: newAccountsThisMonth } = await supabase
+      const { count: newAccountsThisMonth } = await supabaseBanking
         .from(TABLES.ACCOUNTS)
         .select('*', { count: 'exact', head: true })
         .gte('created_at', startOfMonth.toISOString());
 
       // Get account type distribution
-      const { data: typeData } = await supabase
+      const { data: typeData } = await supabaseBanking
         .from(TABLES.ACCOUNTS)
         .select('account_type')
         .eq('account_status', 'ACTIVE');
@@ -197,7 +197,7 @@ export function Accounts() {
         const date = new Date(today.getFullYear(), today.getMonth() - i, 1);
         const nextMonth = new Date(today.getFullYear(), today.getMonth() - i + 1, 1);
         
-        const { count } = await supabase
+        const { count } = await supabaseBanking
           .from(TABLES.ACCOUNTS)
           .select('*', { count: 'exact', head: true })
           .gte('created_at', date.toISOString())

--- a/src/pages/Analytics.jsx
+++ b/src/pages/Analytics.jsx
@@ -27,7 +27,6 @@ import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Progress } from '@/components/ui/progress';
 import { DatePickerWithRange } from '@/components/ui/date-range-picker';
-import { supabase, TABLES } from '@/lib/supabase';
 import { ComparisonWidget } from '@/components/widgets/ComparisonWidget';
 import { toast } from 'sonner';
 import {

--- a/src/pages/Compliance.jsx
+++ b/src/pages/Compliance.jsx
@@ -32,7 +32,6 @@ import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Progress } from '@/components/ui/progress';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { supabase, TABLES } from '@/lib/supabase';
 import { ComparisonWidget } from '@/components/widgets/ComparisonWidget';
 import {
   Table,

--- a/src/pages/DelinquencyExecutiveDashboard.tsx
+++ b/src/pages/DelinquencyExecutiveDashboard.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import { format, subMonths, startOfMonth, endOfMonth } from 'date-fns';
 import { ar, enUS } from 'date-fns/locale';
-import { supabase } from '@/lib/supabase';
+import { supabaseBanking } from '@/lib/supabase';
 import { useRTL } from '@/hooks/useRTL';
 
 // ألوان فئات التقادم
@@ -96,7 +96,7 @@ const DelinquencyExecutiveDashboard = () => {
   };
 
   const fetchPortfolioSummary = async () => {
-    const { data, error } = await supabase
+    const { data, error } = await supabaseBanking
       .from('executive_delinquency_summary')
       .select('*')
       .order('snapshot_date', { ascending: false })
@@ -108,7 +108,7 @@ const DelinquencyExecutiveDashboard = () => {
   };
 
   const fetchAgingDistribution = async () => {
-    const { data, error } = await supabase
+    const { data, error } = await supabaseBanking
       .from('aging_distribution')
       .select('*')
       .order('display_order');
@@ -118,7 +118,7 @@ const DelinquencyExecutiveDashboard = () => {
   };
 
   const fetchCollectionTrends = async () => {
-    const { data, error } = await supabase
+    const { data, error } = await supabaseBanking
       .from('collection_rates')
       .select('*')
       .eq('period_type', 'MONTHLY')
@@ -130,7 +130,7 @@ const DelinquencyExecutiveDashboard = () => {
   };
 
   const fetchTopDelinquents = async () => {
-    const { data, error } = await supabase
+    const { data, error } = await supabaseBanking
       .from('top_delinquent_customers')
       .select('*')
       .limit(10);
@@ -140,7 +140,7 @@ const DelinquencyExecutiveDashboard = () => {
   };
 
   const fetchPerformanceComparison = async () => {
-    const { data, error } = await supabase
+    const { data, error } = await supabaseBanking
       .from('executive_delinquency_summary')
       .select('*')
       .order('snapshot_date', { ascending: false })

--- a/src/pages/Loans.jsx
+++ b/src/pages/Loans.jsx
@@ -26,7 +26,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Progress } from '@/components/ui/progress';
-import { supabase, TABLES } from '@/lib/supabase';
+import { supabaseBanking, TABLES } from '@/lib/supabase';
 import { ComparisonWidget } from '@/components/widgets/ComparisonWidget';
 import { toast } from 'sonner';
 import {
@@ -109,7 +109,7 @@ export function Loans() {
   const fetchLoans = async () => {
     try {
       setLoading(true);
-      let query = supabase
+      let query = supabaseBanking
         .from(TABLES.LOAN_ACCOUNTS)
         .select(`
           *,
@@ -147,24 +147,24 @@ export function Loans() {
   const fetchLoanStats = async () => {
     try {
       // Get total loans count
-      const { count: totalLoans } = await supabase
+      const { count: totalLoans } = await supabaseBanking
         .from(TABLES.LOAN_ACCOUNTS)
         .select('*', { count: 'exact', head: true });
 
       // Get active loans
-      const { count: activeLoans } = await supabase
+      const { count: activeLoans } = await supabaseBanking
         .from(TABLES.LOAN_ACCOUNTS)
         .select('*', { count: 'exact', head: true })
         .in('loan_status', ['ACTIVE', 'DISBURSED']);
 
       // Get overdue loans
-      const { count: overdueLoans } = await supabase
+      const { count: overdueLoans } = await supabaseBanking
         .from(TABLES.LOAN_ACCOUNTS)
         .select('*', { count: 'exact', head: true })
         .eq('loan_status', 'OVERDUE');
 
       // Get total portfolio value
-      const { data: portfolioData } = await supabase
+      const { data: portfolioData } = await supabaseBanking
         .from(TABLES.LOAN_ACCOUNTS)
         .select('outstanding_balance')
         .in('loan_status', ['ACTIVE', 'DISBURSED', 'OVERDUE']);
@@ -177,7 +177,7 @@ export function Loans() {
       startOfMonth.setDate(1);
       startOfMonth.setHours(0, 0, 0, 0);
 
-      const { data: disbursedData } = await supabase
+      const { data: disbursedData } = await supabaseBanking
         .from(TABLES.LOAN_ACCOUNTS)
         .select('loan_amount')
         .eq('loan_status', 'DISBURSED')
@@ -187,7 +187,7 @@ export function Loans() {
         sum + parseFloat(loan.loan_amount || 0), 0) || 0;
 
       // Calculate average interest rate
-      const { data: interestData } = await supabase
+      const { data: interestData } = await supabaseBanking
         .from(TABLES.LOAN_ACCOUNTS)
         .select('interest_rate')
         .in('loan_status', ['ACTIVE', 'DISBURSED']);
@@ -197,7 +197,7 @@ export function Loans() {
         : 0;
 
       // Calculate NPL ratio (Non-Performing Loans)
-      const { count: defaultedLoans } = await supabase
+      const { count: defaultedLoans } = await supabaseBanking
         .from(TABLES.LOAN_ACCOUNTS)
         .select('*', { count: 'exact', head: true })
         .in('loan_status', ['OVERDUE', 'DEFAULTED']);
@@ -210,7 +210,7 @@ export function Loans() {
       const collectionRate = 85 + Math.random() * 10; // Mock 85-95%
 
       // Get loan type distribution
-      const { data: typeData } = await supabase
+      const { data: typeData } = await supabaseBanking
         .from(TABLES.LOAN_ACCOUNTS)
         .select('loan_type, outstanding_balance')
         .in('loan_status', ['ACTIVE', 'DISBURSED']);
@@ -257,7 +257,7 @@ export function Loans() {
         const date = new Date(today.getFullYear(), today.getMonth() - i, 1);
         const nextMonth = new Date(today.getFullYear(), today.getMonth() - i + 1, 1);
         
-        const { data: disbursedData } = await supabase
+        const { data: disbursedData } = await supabaseBanking
           .from(TABLES.LOAN_ACCOUNTS)
           .select('loan_amount')
           .gte('disbursement_date', date.toISOString())
@@ -266,7 +266,7 @@ export function Loans() {
         const disbursed = disbursedData?.reduce((sum, loan) => 
           sum + parseFloat(loan.loan_amount || 0), 0) || 0;
 
-        const { count: applications } = await supabase
+        const { count: applications } = await supabaseBanking
           .from(TABLES.LOAN_ACCOUNTS)
           .select('*', { count: 'exact', head: true })
           .gte('created_at', date.toISOString())

--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -29,7 +29,6 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { DatePickerWithRange } from '@/components/ui/date-range-picker';
-import { supabase, TABLES } from '@/lib/supabase';
 import { ComparisonWidget } from '@/components/widgets/ComparisonWidget';
 import { toast } from 'sonner';
 import {

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -23,7 +23,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import { supabase, TABLES } from '@/lib/supabase';
+import { supabaseBanking, TABLES } from '@/lib/supabase';
 import { ComparisonWidget } from '@/components/widgets/ComparisonWidget';
 import { toast } from 'sonner';
 import { DatePickerWithRange } from '@/components/ui/date-range-picker';
@@ -91,12 +91,12 @@ export function Transactions() {
     fetchTransactionTrends();
     
     // Set up real-time subscription
-    const subscription = supabase
+    const subscription = supabaseBanking
       .channel('transactions-changes')
-      .on('postgres_changes', { 
-        event: '*', 
-        schema: 'public', 
-        table: 'transactions' 
+      .on('postgres_changes', {
+        event: '*',
+        schema: 'kastle_banking',
+        table: 'transactions'
       }, handleRealtimeUpdate)
       .subscribe();
 
@@ -126,7 +126,7 @@ export function Transactions() {
   const fetchTransactions = async () => {
     try {
       setLoading(true);
-      let query = supabase
+      let query = supabaseBanking
         .from(TABLES.TRANSACTIONS)
         .select(`
           *,
@@ -170,24 +170,24 @@ export function Transactions() {
   const fetchTransactionStats = async () => {
     try {
       // Get total transactions count
-      const { count: totalTransactions } = await supabase
+      const { count: totalTransactions } = await supabaseBanking
         .from(TABLES.TRANSACTIONS)
         .select('*', { count: 'exact', head: true });
 
       // Get completed transactions for success rate
-      const { count: completedTransactions } = await supabase
+      const { count: completedTransactions } = await supabaseBanking
         .from(TABLES.TRANSACTIONS)
         .select('*', { count: 'exact', head: true })
         .eq('transaction_status', 'COMPLETED');
 
       // Get pending transactions
-      const { count: pendingTransactions } = await supabase
+      const { count: pendingTransactions } = await supabaseBanking
         .from(TABLES.TRANSACTIONS)
         .select('*', { count: 'exact', head: true })
         .eq('transaction_status', 'PENDING');
 
       // Get total volume
-      const { data: volumeData } = await supabase
+      const { data: volumeData } = await supabaseBanking
         .from(TABLES.TRANSACTIONS)
         .select('amount')
         .eq('transaction_status', 'COMPLETED');
@@ -200,7 +200,7 @@ export function Transactions() {
         : 0;
 
       // Get hourly distribution for peak hour
-      const { data: hourlyData } = await supabase
+      const { data: hourlyData } = await supabaseBanking
         .from(TABLES.TRANSACTIONS)
         .select('transaction_date')
         .eq('transaction_status', 'COMPLETED')
@@ -220,7 +220,7 @@ export function Transactions() {
       const dailyAverage = Math.round(totalTransactions / 30);
 
       // Get type distribution
-      const { data: typeData } = await supabase
+      const { data: typeData } = await supabaseBanking
         .from(TABLES.TRANSACTIONS)
         .select('transaction_type')
         .eq('transaction_status', 'COMPLETED');
@@ -270,7 +270,7 @@ export function Transactions() {
         const nextDate = new Date(date);
         nextDate.setDate(date.getDate() + 1);
         
-        const { count, data: volumeData } = await supabase
+        const { count, data: volumeData } = await supabaseBanking
           .from(TABLES.TRANSACTIONS)
           .select('amount', { count: 'exact' })
           .gte('transaction_date', date.toISOString())

--- a/src/services/dashboardService.js.backup
+++ b/src/services/dashboardService.js.backup
@@ -1,5 +1,5 @@
 // src/services/dashboardService.js
-import { supabase, TABLES, formatApiResponse, isSupabaseConfigured } from '@/lib/supabase';
+import { supabaseBanking, TABLES, formatApiResponse, isSupabaseConfigured } from '@/lib/supabase';
 import { MockDashboardService } from './mockDashboardService';
 
 export class DashboardService {
@@ -15,30 +15,30 @@ export class DashboardService {
 
     try {
       // Get total customers
-      const { count: totalCustomers, error: customersError } = await supabase
+      const { count: totalCustomers, error: customersError } = await supabaseBanking
         .from(TABLES.CUSTOMERS)
         .select('*', { count: 'exact', head: true });
 
       // Get total accounts
-      const { count: totalAccounts, error: accountsError } = await supabase
+      const { count: totalAccounts, error: accountsError } = await supabaseBanking
         .from(TABLES.ACCOUNTS)
         .select('*', { count: 'exact', head: true });
 
       // Get total deposits (sum of current_balance for all accounts)
-      const { data: depositsData, error: depositsError } = await supabase
+      const { data: depositsData, error: depositsError } = await supabaseBanking
         .from(TABLES.ACCOUNTS)
         .select('current_balance')
         .eq('account_status', 'ACTIVE');
 
       // Get total loans (sum of outstanding_balance for all loan accounts)
-      const { data: loansData, error: loansError } = await supabase
+      const { data: loansData, error: loansError } = await supabaseBanking
         .from(TABLES.LOAN_ACCOUNTS)
         .select('outstanding_balance')
         .in('loan_status', ['ACTIVE', 'DISBURSED']);
 
       // Get daily transactions count
       const today = new Date().toISOString().split('T')[0];
-      const { count: dailyTransactions, error: transactionsError } = await supabase
+      const { count: dailyTransactions, error: transactionsError } = await supabaseBanking
         .from(TABLES.TRANSACTIONS)
         .select('*', { count: 'exact', head: true })
         .gte('transaction_date', today);
@@ -92,25 +92,25 @@ export class DashboardService {
 
       // Get current month metrics
       const [currentCustomers, currentTransactions, currentAccounts] = await Promise.all([
-        supabase.from(TABLES.CUSTOMERS)
+        supabaseBanking.from(TABLES.CUSTOMERS)
           .select('*', { count: 'exact', head: true })
           .gte('created_at', currentMonthStart)
           .lte('created_at', currentMonthEnd),
         
-        supabase.from(TABLES.TRANSACTIONS)
+        supabaseBanking.from(TABLES.TRANSACTIONS)
           .select('transaction_amount', { count: 'exact' })
           .gte('transaction_date', currentMonthStart)
           .lte('transaction_date', currentMonthEnd)
           .eq('status', 'COMPLETED'),
         
-        supabase.from(TABLES.ACCOUNTS)
+        supabaseBanking.from(TABLES.ACCOUNTS)
           .select('current_balance')
           .eq('account_status', 'ACTIVE')
       ]);
 
       // Get previous month metrics
       const [previousCustomers, previousTransactions] = await Promise.all([
-        supabase.from(TABLES.CUSTOMERS)
+        supabaseBanking.from(TABLES.CUSTOMERS)
           .select('*', { count: 'exact', head: true })
           .gte('created_at', previousMonthStart)
           .lte('created_at', previousMonthEnd),


### PR DESCRIPTION
## Summary
- ensure data queries use the kastle_banking client
- remove unused `supabase` imports

## Testing
- `npm run lint` *(fails: 'no-unused-vars' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68845f8d11248329b6c63c3df5e3c4b5