### PR TITLE
Vercel build with runtime error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -42,11 +42,6 @@
     "VITE_DEV_MODE": "false",
     "VITE_LOG_LEVEL": "error",
     "NODE_ENV": "production"
-  },
-  "functions": {
-    "app/api/**/*.js": {
-      "runtime": "nodejs18.x"
-    }
   }
 }
 


### PR DESCRIPTION
Remove unused `functions` configuration from `vercel.json` to fix Vercel deployment error.

---

[Open in Web](https://cursor.com/agents?id=bc-e906546e-c1f2-4ebe-8731-fcb7c4cd7e90) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e906546e-c1f2-4ebe-8731-fcb7c4cd7e90) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)