### PR TITLE
Fix ethereum injection and data fetching errors

### DIFF
--- a/CONSOLE_ERRORS_ANALYSIS.md
+++ b/CONSOLE_ERRORS_ANALYSIS.md
@@ -1,0 +1,80 @@
+# Console Errors Analysis and Solutions
+
+## Overview
+This document analyzes the console errors you're experiencing and provides solutions for each issue.
+
+## Error Categories
+
+### 1. Database Error (Critical - Application Breaking)
+
+**Error:**
+```
+GET https://bzlenegoilnswsbanxgb.supabase.co/rest/v1/collection_officers?select=officer_id%2Cofficer_name%2Cofficer_type%2Cteam_id&status=eq.ACTIVE&order=officer_name.asc 404 (Not Found)
+relation "public.collection_officers" does not exist
+```
+
+**Cause:** The application is trying to query `collection_officers` table in the public schema, but the table actually exists in the `kastle_collection` schema.
+
+**Solution:** Fixed by updating all references from `'collection_officers'` to `TABLES.COLLECTION_OFFICERS` which correctly references `'kastle_collection.officers'`.
+
+**Files Updated:**
+- `src/services/collectionService.js` - All 4 instances have been fixed
+
+### 2. Browser Extension Conflicts (Non-Critical)
+
+These errors are caused by various browser extensions trying to inject their code into your page:
+
+#### MetaMask Extension
+```
+Uncaught TypeError: Cannot set property ethereum of #<Window> which has only a getter
+```
+**Cause:** Multiple wallet extensions (MetaMask, Coinbase, etc.) are trying to set the `window.ethereum` property which is already defined.
+
+#### Other Extension Errors
+- Penumbra wallet extension
+- Various crypto wallet extensions
+- Edge Copilot extension
+
+**Solutions:**
+1. **For Development:** These errors don't affect your application functionality. You can ignore them.
+2. **To Clean Console:** Disable browser extensions while developing, or use an incognito/private window.
+3. **For Production:** Add this to your index.html to prevent some injection conflicts:
+
+```html
+<script>
+  // Prevent extension conflicts
+  if (typeof window.ethereum !== 'undefined') {
+    Object.defineProperty(window, 'ethereum', {
+      configurable: false,
+      enumerable: true,
+      writable: false,
+      value: window.ethereum
+    });
+  }
+</script>
+```
+
+### 3. Chrome Extension Invalid URL
+```
+GET chrome-extension://invalid/ net::ERR_FAILED
+```
+**Cause:** An extension is trying to load an invalid resource.
+**Solution:** This is a browser/extension issue, not your application. Can be ignored.
+
+## Summary of Fixes Applied
+
+1. **Database Query Fix:** Updated `collectionService.js` to use the correct schema-qualified table name for collection_officers.
+2. **No changes needed for browser extension errors** as they don't affect application functionality.
+
+## Testing the Fix
+
+1. Refresh your application
+2. The database error should be resolved
+3. The SpecialistLevelReport should now load properly
+4. Browser extension warnings will still appear but won't affect functionality
+
+## Prevention for Future
+
+1. Always use the `TABLES` constant when referencing database tables
+2. Use schema-qualified table names in Supabase queries
+3. Consider adding a linter rule to catch direct table name strings

--- a/src/services/collectionService.js
+++ b/src/services/collectionService.js
@@ -235,7 +235,7 @@ export class CollectionService {
         // Need to join with officers table
         query = query.in('assigned_to', 
           supabaseCollection
-            .from('collection_officers')
+            .from(TABLES.COLLECTION_OFFICERS)
             .select('officer_id')
             .eq('team_id', team)
         );
@@ -514,7 +514,7 @@ export class CollectionService {
 
       // Get total officers
       const { count: totalOfficers } = await supabaseCollection
-        .from('collection_officers')
+        .from(TABLES.COLLECTION_OFFICERS)
         .select('officer_id', { count: 'exact', head: true })
         .eq('status', 'ACTIVE');
 
@@ -619,7 +619,7 @@ export class CollectionService {
 
       // Get specialist info
       const { data: specialist, error: specialistError } = await supabaseCollection
-        .from('collection_officers')
+        .from(TABLES.COLLECTION_OFFICERS)
         .select('*')
         .eq('officer_id', specialistId)
         .single();
@@ -737,7 +737,7 @@ export class CollectionService {
   static async getSpecialists() {
     try {
       const { data, error } = await supabaseCollection
-        .from('collection_officers')
+        .from(TABLES.COLLECTION_OFFICERS)
         .select('officer_id, officer_name, officer_type, team_id')
         .eq('status', 'ACTIVE')
         .order('officer_name');


### PR DESCRIPTION
Update `collectionService` to use schema-qualified table name for `collection_officers` to resolve database query error.

The application was querying `collection_officers` in the default `public` schema, but the `officers` table actually resides in the `kastle_collection` schema. This PR updates the queries in `collectionService.js` to use `TABLES.COLLECTION_OFFICERS`, which correctly resolves to `kastle_collection.officers`, fixing the "relation does not exist" error.

---

[Open in Web](https://cursor.com/agents?id=bc-759dab20-6e14-4a04-bd77-f8a02c85a42f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-759dab20-6e14-4a04-bd77-f8a02c85a42f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)