### PR TITLE
Fix building not defined error on home page

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -11,7 +11,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@300;400;500;600;700&family=Tajawal:wght@300;400;500;700&family=Cairo:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Ethereum conflict resolver - must be loaded first -->
     <script src="/ethereum-conflict-resolver.js"></script>
-    <script type="module" crossorigin src="/assets/index-BtXpiQyl.js"></script>
+    <script type="module" crossorigin src="/assets/index-B1PMpBtl.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index-DHuG_kI8.css">
   </head>
   <body>

--- a/src/components/dashboard/BranchLevelReport.jsx
+++ b/src/components/dashboard/BranchLevelReport.jsx
@@ -29,7 +29,7 @@ import {
   AreaChart, Treemap
 } from 'recharts';
 import { 
-  Building, TrendingUp, Users, DollarSign, Phone, MessageSquare,
+  Building2, TrendingUp, Users, DollarSign, Phone, MessageSquare,
   Calendar, Filter, Download, RefreshCw, ChevronRight, Eye,
   AlertCircle, CheckCircle, Clock, Target, Award, ArrowUpRight,
   ArrowDownRight, Loader2, MapPin, BarChart3, Trophy
@@ -172,7 +172,7 @@ const BranchLevelReport = () => {
         <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
           <div>
             <h1 className="text-3xl font-bold text-gray-900 flex items-center gap-2">
-              <Building className="h-8 w-8 text-primary" />
+                              <Building2 className="h-8 w-8 text-primary" />
               تقرير مستوى الفرع
             </h1>
             <p className="text-gray-600 mt-1">تحليل شامل لأداء التحصيل على مستوى الفرع</p>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -333,7 +333,7 @@ const getNavigationItems = (t) => [
     {
       title: 'تقرير مستوى الفرع',
       href: '/collection/branch-report',
-      icon: Building,
+      icon: Building2,
       badge: 'جديد',
       badgeVariant: 'default'
     },

--- a/src/pages/EarlyWarningDashboard.tsx
+++ b/src/pages/EarlyWarningDashboard.tsx
@@ -17,7 +17,7 @@ import {
 import { 
   AlertTriangle, TrendingUp, Users, Activity, Bell, Shield,
   Eye, DollarSign, Calendar, Clock, Zap, Target, AlertCircle,
-  ChevronRight, Filter, RefreshCw, FileWarning, UserX, Building
+  ChevronRight, Filter, RefreshCw, FileWarning, UserX, Building2
 } from 'lucide-react';
 
 const EarlyWarningDashboard = () => {
@@ -509,7 +509,7 @@ const EarlyWarningDashboard = () => {
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                <Building className="h-5 w-5" />
+                <Building2 className="h-5 w-5" />
                 Industry Risk Analysis
               </CardTitle>
             </CardHeader>

--- a/src/services/earlyWarningService.js
+++ b/src/services/earlyWarningService.js
@@ -18,7 +18,7 @@ import {
 import { 
   AlertTriangle, TrendingUp, Users, Activity, Bell, Shield,
   Eye, DollarSign, Calendar, Clock, Zap, Target, AlertCircle,
-  ChevronRight, Filter, RefreshCw, FileWarning, UserX, Building,
+  ChevronRight, Filter, RefreshCw, FileWarning, UserX, Building2,
   Phone, Mail, Loader2
 } from 'lucide-react';
 import { EarlyWarningService } from '@/services/earlyWarningService';
@@ -495,7 +495,7 @@ const EarlyWarningDashboard = () => {
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
-                  <Building className="h-5 w-5" />
+                  <Building2 className="h-5 w-5" />
                   Industry Risk Analysis
                 </CardTitle>
               </CardHeader>


### PR DESCRIPTION
Replace `Building` icon with `Building2` from `lucide-react` to resolve `ReferenceError` in production.

The `Building` icon was causing a `ReferenceError` in production builds, likely due to bundling issues or inconsistent availability across `lucide-react` versions. Switching to `Building2` ensures compatibility and resolves the runtime error.

---

[Open in Web](https://cursor.com/agents?id=bc-7342fc7b-d35e-42d0-ae91-ffed706b4ca0) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-7342fc7b-d35e-42d0-ae91-ffed706b4ca0) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)