### PR TITLE
Fix phone undefined error on product report

### DIFF
--- a/src/components/dashboard/ProductLevelReport.jsx
+++ b/src/components/dashboard/ProductLevelReport.jsx
@@ -39,7 +39,8 @@ import {
   Package, TrendingUp, Users, DollarSign, AlertTriangle, MapPin,
   Calendar, Filter, Download, RefreshCw, ChevronRight, Eye,
   AlertCircle, CheckCircle, Clock, Target, Award, ArrowUpRight,
-  ArrowDownRight, Loader2, BarChart3, Shield, Zap, CreditCard
+  ArrowDownRight, Loader2, BarChart3, Shield, Zap, CreditCard,
+  Phone, MessageSquare
 } from 'lucide-react';
 import { ProductReportService } from '@/services/productReportService';
 import { BranchReportService } from '@/services/branchReportService';


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `Phone` and `MessageSquare` imports to fix `ReferenceError: Phone is not defined` on the product report page.

---

[Open in Web](https://cursor.com/agents?id=bc-79895af3-b3cf-461c-ab24-307866d846e9) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-79895af3-b3cf-461c-ab24-307866d846e9) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)