### PR TITLE
Fix duplicate symbol errors in build

### DIFF
--- a/src/components/dashboard/ProductLevelReport.jsx
+++ b/src/components/dashboard/ProductLevelReport.jsx
@@ -41,7 +41,7 @@ import {
   Calendar, Filter, Download, RefreshCw, ChevronRight, Eye,
   AlertCircle, CheckCircle, Clock, Target, Award, ArrowUpRight,
   ArrowDownRight, Loader2, BarChart3, Shield, Zap, CreditCard,
-  Phone, MessageSquare, Trophy, Zap, Shield, BarChart3
+  Phone, MessageSquare, Trophy
 } from 'lucide-react';
 import { ProductReportService } from '@/services/productReportService';
 import { BranchReportService } from '@/services/branchReportService';

--- a/src/index.css
+++ b/src/index.css
@@ -1,15 +1,13 @@
+/* src/index.css */
+/* Import RTL styles */
 @import './styles/rtl.css';
 
-/* src/index.css */
 /* Import grid layout styles */
 @import './styles/grid-layout-styles.css';
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Import RTL styles */
-@import './styles/rtl.css';
 
 @layer base {
   :root {


### PR DESCRIPTION
Fixes build errors by removing duplicate Lucide React icon imports and correcting CSS `@import` order.

---

[Open in Web](https://cursor.com/agents?id=bc-9dceea6e-9acd-4238-8eb7-3a16901a662e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-9dceea6e-9acd-4238-8eb7-3a16901a662e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)