### PR TITLE
Fix Supabase schema and port errors

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -40,46 +40,81 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
       }
     });
 
-// Use the main client for all operations since schema-qualified table names work
-export const supabaseBanking = supabase;
-export const supabaseCollection = supabase;
+// Create schema-specific clients
+export const supabaseBanking = createClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        autoRefreshToken: true,
+        persistSession: true,
+        detectSessionInUrl: true
+      },
+      db: {
+        schema: 'kastle_banking'
+      },
+      realtime: {
+        params: {
+          eventsPerSecond: 10
+        }
+      }
+    });
 
-// Database schema constants - using schema-qualified table names
+export const supabaseCollection = createClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        autoRefreshToken: true,
+        persistSession: true,
+        detectSessionInUrl: true
+      },
+      db: {
+        schema: 'kastle_collection'
+      },
+      realtime: {
+        params: {
+          eventsPerSecond: 10
+        }
+      }
+    });
+
+// Database schema constants - using table names only (schema is set in the client)
 export const TABLES = {
-  // kastle_banking schema tables
-  CUSTOMERS: 'kastle_banking.customers',
-  ACCOUNTS: 'kastle_banking.accounts',
-  TRANSACTIONS: 'kastle_banking.transactions',
-  LOAN_ACCOUNTS: 'kastle_banking.loan_accounts',
-  BRANCHES: 'kastle_banking.branches',
-  CURRENCIES: 'kastle_banking.currencies',
-  COUNTRIES: 'kastle_banking.countries',
-  AUDIT_TRAIL: 'kastle_banking.audit_trail',
-  AUTH_USER_PROFILES: 'kastle_banking.auth_user_profiles',
-  REALTIME_NOTIFICATIONS: 'kastle_banking.realtime_notifications',
-  CUSTOMER_ADDRESSES: 'kastle_banking.customer_addresses',
-  CUSTOMER_CONTACTS: 'kastle_banking.customer_contacts',
-  CUSTOMER_DOCUMENTS: 'kastle_banking.customer_documents',
-  CUSTOMER_TYPES: 'kastle_banking.customer_types',
-  PRODUCTS: 'kastle_banking.products',
-  PRODUCT_CATEGORIES: 'kastle_banking.product_categories',
-  BANK_CONFIG: 'kastle_banking.bank_config',
+  // kastle_banking schema tables (use with supabaseBanking client)
+  CUSTOMERS: 'customers',
+  ACCOUNTS: 'accounts',
+  TRANSACTIONS: 'transactions',
+  LOAN_ACCOUNTS: 'loan_accounts',
+  BRANCHES: 'branches',
+  CURRENCIES: 'currencies',
+  COUNTRIES: 'countries',
+  AUDIT_TRAIL: 'audit_trail',
+  AUTH_USER_PROFILES: 'auth_user_profiles',
+  REALTIME_NOTIFICATIONS: 'realtime_notifications',
+  CUSTOMER_ADDRESSES: 'customer_addresses',
+  CUSTOMER_CONTACTS: 'customer_contacts',
+  CUSTOMER_DOCUMENTS: 'customer_documents',
+  CUSTOMER_TYPES: 'customer_types',
+  PRODUCTS: 'products',
+  PRODUCT_CATEGORIES: 'product_categories',
+  BANK_CONFIG: 'bank_config',
   
-  // kastle_collection schema tables
-  COLLECTION_AUDIT_TRAIL: 'kastle_collection.audit_trail',
-  COLLECTION_CALL_RECORDS: 'kastle_collection.call_records',
-  COLLECTION_CAMPAIGNS: 'kastle_collection.campaigns',
-  COLLECTION_CASE_DETAILS: 'kastle_collection.case_details',
-  COLLECTION_INTERACTIONS: 'kastle_collection.interactions',
-  COLLECTION_OFFICERS: 'kastle_collection.officers',
-  COLLECTION_SCORES: 'kastle_collection.scores',
-  COLLECTION_STRATEGIES: 'kastle_collection.strategies',
-  COLLECTION_SYSTEM_PERFORMANCE: 'kastle_collection.system_performance',
-  COLLECTION_TEAMS: 'kastle_collection.teams',
-  DAILY_COLLECTION_SUMMARY: 'kastle_collection.daily_collection_summary',
-  DIGITAL_COLLECTION_ATTEMPTS: 'kastle_collection.digital_collection_attempts',
-  FIELD_VISITS: 'kastle_collection.field_visits',
-  HARDSHIP_APPLICATIONS: 'kastle_collection.hardship_applications'
+  // kastle_collection schema tables (use with supabaseCollection client)
+  COLLECTION_AUDIT_TRAIL: 'audit_trail',
+  COLLECTION_CALL_RECORDS: 'call_records',
+  COLLECTION_CAMPAIGNS: 'collection_campaigns',
+  COLLECTION_CASES: 'collection_cases',
+  COLLECTION_INTERACTIONS: 'collection_interactions',
+  COLLECTION_OFFICERS: 'collection_officers',
+  COLLECTION_SCORES: 'collection_scores',
+  COLLECTION_STRATEGIES: 'collection_strategies',
+  COLLECTION_SYSTEM_PERFORMANCE: 'system_performance',
+  COLLECTION_TEAMS: 'collection_teams',
+  COLLECTION_BUCKETS: 'collection_buckets',
+  PROMISE_TO_PAY: 'promise_to_pay',
+  LEGAL_CASES: 'legal_cases',
+  DAILY_COLLECTION_SUMMARY: 'daily_collection_summary',
+  DIGITAL_COLLECTION_ATTEMPTS: 'digital_collection_attempts',
+  FIELD_VISITS: 'field_visits',
+  HARDSHIP_APPLICATIONS: 'hardship_applications',
+  OFFICER_PERFORMANCE_METRICS: 'officer_performance_metrics',
+  OFFICER_PERFORMANCE_SUMMARY: 'officer_performance_summary',
+  CASE_BUCKET_HISTORY: 'case_bucket_history'
 };
 
 // Helper function to get the appropriate client for a table

--- a/src/pages/DelinquencyExecutiveDashboard.tsx
+++ b/src/pages/DelinquencyExecutiveDashboard.tsx
@@ -99,7 +99,7 @@ const DelinquencyExecutiveDashboard = () => {
     try {
       // Calculate directly from loan_accounts table
       const { data: loanData, error: loanError } = await supabaseBanking
-        .from('kastle_banking.loan_accounts')
+        .from('loan_accounts')
         .select('outstanding_balance, loan_status, overdue_amount, overdue_days');
 
       if (loanError) {
@@ -196,7 +196,7 @@ const DelinquencyExecutiveDashboard = () => {
     try {
       // Try to get real delinquent customers from database
       const { data, error } = await supabaseBanking
-        .from('kastle_banking.loan_accounts')
+        .from('loan_accounts')
         .select(`
           loan_account_number,
           customer_id,

--- a/src/services/collectionService.js
+++ b/src/services/collectionService.js
@@ -52,35 +52,35 @@ export class CollectionService {
 
       // Build query
       let query = supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select(`
           *,
-          kastle_banking.loan_accounts!loan_account_number (
+          loan_accounts!loan_account_number (
             loan_amount,
             outstanding_balance,
             overdue_amount,
             overdue_days,
             product_id,
-            kastle_banking.products!product_id (
+            products!product_id (
               product_name,
               product_type
             )
           ),
-          kastle_banking.customers!customer_id (
+          customers!customer_id (
             full_name,
             customer_type,
-            kastle_banking.customer_contacts!customer_id (
+            customer_contacts!customer_id (
               contact_type,
               contact_value
             )
           ),
-          kastle_collection.collection_officers!assigned_to (
+          collection_officers!assigned_to (
             officer_name,
             officer_type,
             team_id,
             contact_number
           ),
-          kastle_collection.collection_buckets!bucket_id (
+          collection_buckets!bucket_id (
             bucket_name,
             min_days,
             max_days
@@ -89,7 +89,7 @@ export class CollectionService {
 
       // Apply filters
       if (search) {
-        query = query.or(`case_number.ilike.%${search}%,kastle_banking.customers.full_name.ilike.%${search}%,loan_account_number.ilike.%${search}%`);
+        query = query.or(`case_number.ilike.%${search}%,customers.full_name.ilike.%${search}%,loan_account_number.ilike.%${search}%`);
       }
 
       if (status && status !== 'all') {
@@ -149,13 +149,13 @@ export class CollectionService {
       const enrichedData = await Promise.all((data || []).map(async (caseItem) => {
         // Get interaction count for this case
         const { count: interactionCount } = await supabaseCollection
-          .from('kastle_collection.collection_interactions')
+          .from('collection_interactions')
           .select('interaction_id', { count: 'exact', head: true })
           .eq('case_id', caseItem.case_id);
 
         // Get promise to pay status
         const { data: activePTP } = await supabaseCollection
-          .from('kastle_collection.promise_to_pay')
+          .from('promise_to_pay')
           .select('ptp_id, ptp_date, ptp_amount')
           .eq('case_id', caseItem.case_id)
           .eq('status', 'ACTIVE')
@@ -208,21 +208,21 @@ export class CollectionService {
     try {
       // Get case info with all related data
       const { data: caseData, error: caseError } = await supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select(`
           *,
-          kastle_banking.loan_accounts!loan_account_number (
+          loan_accounts!loan_account_number (
             *,
-            kastle_banking.products!product_id (*)
+            products!product_id (*)
           ),
-          kastle_banking.customers!customer_id (
+          customers!customer_id (
             *,
-            kastle_banking.customer_contacts!customer_id (*),
-            kastle_banking.customer_addresses!customer_id (*)
+            customer_contacts!customer_id (*),
+            customer_addresses!customer_id (*)
           ),
-          kastle_collection.collection_officers!assigned_to (*),
-          kastle_collection.collection_strategies!strategy_id (*),
-          kastle_collection.collection_buckets!bucket_id (*)
+          collection_officers!assigned_to (*),
+          collection_strategies!strategy_id (*),
+          collection_buckets!bucket_id (*)
         `)
         .eq('case_id', caseId)
         .single();
@@ -231,10 +231,10 @@ export class CollectionService {
 
       // Get interactions
       const { data: interactions, error: interactionsError } = await supabaseCollection
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select(`
           *,
-          kastle_collection.collection_officers!officer_id (
+          collection_officers!officer_id (
             officer_name,
             officer_type
           )
@@ -244,10 +244,10 @@ export class CollectionService {
 
       // Get promises to pay
       const { data: promisesToPay, error: ptpError } = await supabaseCollection
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .select(`
           *,
-          kastle_collection.collection_officers!officer_id (
+          collection_officers!officer_id (
             officer_name
           )
         `)
@@ -256,10 +256,10 @@ export class CollectionService {
 
       // Get field visits
       const { data: fieldVisits, error: visitsError } = await supabaseCollection
-        .from('kastle_collection.field_visits')
+        .from('field_visits')
         .select(`
           *,
-          kastle_collection.collection_officers!officer_id (
+          collection_officers!officer_id (
             officer_name
           )
         `)
@@ -268,14 +268,14 @@ export class CollectionService {
 
       // Get legal case if exists
       const { data: legalCase, error: legalError } = await supabaseCollection
-        .from('kastle_collection.legal_cases')
+        .from('legal_cases')
         .select('*')
         .eq('case_id', caseId)
         .single();
 
       // Get payment history
       const { data: payments, error: paymentsError } = await supabaseBanking
-        .from('kastle_banking.transactions')
+        .from('transactions')
         .select('*')
         .eq('account_number', caseData?.account_number)
         .eq('transaction_type_id', 'LOAN_REPAYMENT')
@@ -284,7 +284,7 @@ export class CollectionService {
 
       // Get collection score history
       const { data: scoreHistory, error: scoreError } = await supabaseCollection
-        .from('kastle_collection.collection_scores')
+        .from('collection_scores')
         .select('*')
         .eq('case_id', caseId)
         .order('score_date', { ascending: false })
@@ -323,7 +323,7 @@ export class CollectionService {
 
       // Build base query for cases
       let casesQuery = supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select('case_id, total_outstanding, days_past_due, case_status, priority, bucket_id, assigned_to');
 
       // Apply filters
@@ -347,7 +347,7 @@ export class CollectionService {
       let filteredCases = cases || [];
       if (team && team !== 'all') {
         const { data: teamOfficers } = await supabaseCollection
-          .from('kastle_collection.collection_officers')
+          .from('collection_officers')
           .select('officer_id')
           .eq('team_id', team);
         
@@ -366,7 +366,7 @@ export class CollectionService {
       startOfMonth.setHours(0, 0, 0, 0);
 
       const { data: monthlyRecovery } = await supabaseCollection
-        .from('kastle_collection.daily_collection_summary')
+        .from('daily_collection_summary')
         .select('total_collected')
         .gte('summary_date', startOfMonth.toISOString().split('T')[0]);
 
@@ -375,7 +375,7 @@ export class CollectionService {
 
       // Get bucket distribution
       const { data: buckets } = await supabaseCollection
-        .from('kastle_collection.collection_buckets')
+        .from('collection_buckets')
         .select('bucket_id, bucket_name, min_days, max_days');
 
       const bucketDistribution = buckets?.map(bucket => {
@@ -424,11 +424,11 @@ export class CollectionService {
 
       // Get team performance
       const { data: teams } = await supabaseCollection
-        .from('kastle_collection.collection_teams')
+        .from('collection_teams')
         .select(`
           team_id,
           team_name,
-          kastle_collection.collection_officers!team_id (
+          collection_officers!team_id (
             officer_id,
             officer_name
           )
@@ -440,7 +440,7 @@ export class CollectionService {
         
         // Get team recovery
         const { data: teamRecovery } = await supabaseCollection
-          .from('kastle_collection.officer_performance_summary')
+          .from('officer_performance_summary')
           .select('total_collected')
           .in('officer_id', teamOfficerIds)
           .gte('summary_date', startOfMonth.toISOString().split('T')[0]);
@@ -515,7 +515,7 @@ export class CollectionService {
 
       // Get daily summaries
       const { data: dailySummaries, error: summaryError } = await supabaseCollection
-        .from('kastle_collection.daily_collection_summary')
+        .from('daily_collection_summary')
         .select('*')
         .gte('summary_date', startDate.toISOString().split('T')[0])
         .lte('summary_date', endDate.toISOString().split('T')[0])
@@ -525,10 +525,10 @@ export class CollectionService {
 
       // Get top officers performance
       const { data: officerPerformance, error: officersError } = await supabaseCollection
-        .from('kastle_collection.officer_performance_summary')
+        .from('officer_performance_summary')
         .select(`
           *,
-          kastle_collection.collection_officers!officer_id (
+          collection_officers!officer_id (
             officer_name,
             officer_type,
             team_id,
@@ -543,17 +543,17 @@ export class CollectionService {
 
       // Get team comparison
       const { data: teams, error: teamsError } = await supabaseCollection
-        .from('kastle_collection.collection_teams')
+        .from('collection_teams')
         .select('*');
 
       const teamComparison = await Promise.all((teams || []).map(async (team) => {
         const { data: teamData } = await supabaseCollection
-          .from('kastle_collection.officer_performance_summary')
+          .from('officer_performance_summary')
           .select('total_collected, total_cases, contact_rate')
           .eq('summary_date', endDate.toISOString().split('T')[0])
           .in('officer_id', 
             supabaseCollection
-              .from('kastle_collection.collection_officers')
+              .from('collection_officers')
               .select('officer_id')
               .eq('team_id', team.team_id)
           );
@@ -576,7 +576,7 @@ export class CollectionService {
 
       // Get campaign effectiveness
       const { data: campaigns, error: campaignsError } = await supabaseCollection
-        .from('kastle_collection.collection_campaigns')
+        .from('collection_campaigns')
         .select('*')
         .in('status', ['ACTIVE', 'COMPLETED'])
         .order('created_at', { ascending: false })
@@ -584,7 +584,7 @@ export class CollectionService {
 
       // Get channel performance
       const { data: channelPerformance } = await supabaseCollection
-        .from('kastle_collection.digital_collection_attempts')
+        .from('digital_collection_attempts')
         .select('channel_type, payment_made, payment_amount')
         .gte('sent_datetime', startDate.toISOString());
 
@@ -679,7 +679,7 @@ export class CollectionService {
       startDate.setMonth(startDate.getMonth() - (period === 'daily' ? 1 : period === 'weekly' ? 3 : 12));
 
       const { data: trends, error: trendsError } = await supabaseCollection
-        .from('kastle_collection.daily_collection_summary')
+        .from('daily_collection_summary')
         .select('summary_date, total_collected, collection_rate, calls_made, ptps_created, ptps_kept')
         .gte('summary_date', startDate.toISOString().split('T')[0])
         .lte('summary_date', endDate.toISOString().split('T')[0])
@@ -689,14 +689,14 @@ export class CollectionService {
 
       // Get bucket movement analysis
       const { data: bucketMovements, error: bucketError } = await supabaseCollection
-        .from('kastle_collection.case_bucket_history')
+        .from('case_bucket_history')
         .select(`
           from_bucket_id,
           to_bucket_id,
           movement_date,
           case_count,
           total_amount,
-          kastle_collection.collection_buckets!from_bucket_id (
+          collection_buckets!from_bucket_id (
             bucket_name
           )
         `)
@@ -705,7 +705,7 @@ export class CollectionService {
 
       // Get PTP analysis
       const { data: ptpData, error: ptpError } = await supabaseCollection
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .select('status, ptp_amount, created_at, kept_date, broken_date')
         .gte('created_at', startDate.toISOString());
 
@@ -721,7 +721,7 @@ export class CollectionService {
 
       // Channel effectiveness from digital attempts
       const { data: digitalAttempts } = await supabaseCollection
-        .from('kastle_collection.digital_collection_attempts')
+        .from('digital_collection_attempts')
         .select('channel_type, payment_made, payment_amount, response_received')
         .gte('sent_datetime', startDate.toISOString());
 
@@ -828,7 +828,7 @@ export class CollectionService {
         case 'summary':
           // Get overall collection summary
           const { data: summary } = await supabaseCollection
-            .from('kastle_collection.daily_collection_summary')
+            .from('daily_collection_summary')
             .select('*')
             .gte('summary_date', startDate.toISOString().split('T')[0])
             .lte('summary_date', endDate.toISOString().split('T')[0])
@@ -852,7 +852,7 @@ export class CollectionService {
         case 'detailed':
           // Get detailed collection data by officer
           const { data: officerData } = await supabaseCollection
-            .from('kastle_collection.officer_performance_summary')
+            .from('officer_performance_summary')
             .select(`
               *,
               collection_officers (
@@ -876,7 +876,7 @@ export class CollectionService {
         case 'bucket':
           // Get collection by bucket
           const { data: bucketData } = await supabaseCollection
-            .from('kastle_collection.collection_cases')
+            .from('collection_cases')
             .select(`
               bucket_id,
               total_outstanding,
@@ -923,7 +923,7 @@ export class CollectionService {
         case 'team':
           // Get collection by team
           const { data: teams } = await supabaseCollection
-            .from('kastle_collection.collection_teams')
+            .from('collection_teams')
             .select(`
               *,
               collection_officers (
@@ -936,7 +936,7 @@ export class CollectionService {
             const officerIds = team.kastle_collection?.collection_officers?.map(o => o.officer_id) || [];
             
             const { data: teamData } = await supabaseCollection
-              .from('kastle_collection.officer_performance_summary')
+              .from('officer_performance_summary')
               .select('total_collected, total_cases, contact_rate')
               .in('officer_id', officerIds)
               .gte('summary_date', startDate.toISOString().split('T')[0])
@@ -1001,7 +1001,7 @@ export class CollectionService {
       }
 
       const { data: officerPerformance, error: officersError } = await supabaseCollection
-        .from('kastle_collection.officer_performance_summary')
+        .from('officer_performance_summary')
         .select(`
           *,
           collection_officers (
@@ -1052,7 +1052,7 @@ export class CollectionService {
       }
 
       const { data: teams, error: teamsError } = await supabaseCollection
-        .from('kastle_collection.collection_teams')
+        .from('collection_teams')
         .select(`
           *,
           collection_officers (
@@ -1067,7 +1067,7 @@ export class CollectionService {
         const officerIds = team.kastle_collection?.collection_officers?.map(o => o.officer_id) || [];
         
         const { data: teamData } = await supabaseCollection
-          .from('kastle_collection.officer_performance_summary')
+          .from('officer_performance_summary')
           .select('total_collected, total_cases, contact_rate, ptp_rate')
           .in('officer_id', officerIds)
           .gte('summary_date', startDate.toISOString().split('T')[0])
@@ -1112,7 +1112,7 @@ export class CollectionService {
       const { teamId, officerType, status = 'ACTIVE' } = filters;
 
       let query = supabaseCollection
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select(`
           *,
           collection_teams (
@@ -1150,7 +1150,7 @@ export class CollectionService {
   static async getSpecialists() {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select(`
           officer_id, 
           officer_name, 
@@ -1192,7 +1192,7 @@ export class CollectionService {
 
       // Get specialist info
       const { data: specialist, error: specialistError } = await supabaseCollection
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select('*')
         .eq('officer_id', specialistId)
         .single();
@@ -1201,16 +1201,16 @@ export class CollectionService {
 
       // Get cases assigned to specialist with all loan details
       let casesQuery = supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select(`
           *,
-          kastle_banking.loan_accounts!loan_account_number (
+          loan_accounts!loan_account_number (
             *,
-            kastle_banking.products!product_id (
+            products!product_id (
               product_name,
               product_type
             ),
-            kastle_banking.loan_schedules!loan_account_number (
+            loan_schedules!loan_account_number (
               installment_number,
               due_date,
               principal_amount,
@@ -1220,11 +1220,11 @@ export class CollectionService {
               status
             )
           ),
-          kastle_banking.customers!customer_id (
+          customers!customer_id (
             full_name,
             customer_type,
             national_id,
-            kastle_banking.customer_contacts!customer_id (
+            customer_contacts!customer_id (
               contact_type,
               contact_value
             )
@@ -1245,10 +1245,10 @@ export class CollectionService {
 
       // Get communication logs for the specialist
       const { data: communicationLogs, error: commError } = await supabaseCollection
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select(`
           *,
-          kastle_collection.collection_cases!case_id (
+          collection_cases!case_id (
             loan_account_number,
             customer_id
           )
@@ -1259,13 +1259,13 @@ export class CollectionService {
 
       // Get promises to pay
       const { data: promisesToPay, error: ptpError } = await supabaseCollection
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .select(`
           *,
-          kastle_collection.collection_cases!case_id (
+          collection_cases!case_id (
             loan_account_number,
             customer_id,
-            kastle_banking.customers!customer_id (
+            customers!customer_id (
               full_name
             )
           )
@@ -1441,7 +1441,7 @@ export class CollectionService {
   static async createCollectionCase(caseData) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .insert([{
           ...caseData,
           case_number: `CASE-${Date.now()}`,
@@ -1455,7 +1455,7 @@ export class CollectionService {
 
       // Create initial collection score
       await supabaseCollection
-        .from('kastle_collection.collection_scores')
+        .from('collection_scores')
         .insert([{
           case_id: data.case_id,
           score_date: new Date().toISOString(),
@@ -1477,7 +1477,7 @@ export class CollectionService {
   static async updateCollectionCase(caseId, updates) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .update({
           ...updates,
           updated_at: new Date().toISOString()
@@ -1501,7 +1501,7 @@ export class CollectionService {
   static async logInteraction(interactionData) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .insert([{
           ...interactionData,
           interaction_datetime: new Date().toISOString()
@@ -1529,7 +1529,7 @@ export class CollectionService {
   static async createPromiseToPay(ptpData) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .insert([{
           ...ptpData,
           status: 'ACTIVE',
@@ -1564,7 +1564,7 @@ export class CollectionService {
       }
 
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .update(updateData)
         .eq('ptp_id', ptpId)
         .select()
@@ -1585,7 +1585,7 @@ export class CollectionService {
   static async scheduleFieldVisit(visitData) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.field_visits')
+        .from('field_visits')
         .insert([{
           ...visitData,
           status: 'SCHEDULED',
@@ -1761,7 +1761,7 @@ export class CollectionService {
   static async getTeams() {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_teams')
+        .from('collection_teams')
         .select('*')
         .order('team_name');
 
@@ -1780,7 +1780,7 @@ export class CollectionService {
   static async getStrategies() {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_strategies')
+        .from('collection_strategies')
         .select('*')
         .eq('is_active', true)
         .order('strategy_name');
@@ -1800,7 +1800,7 @@ export class CollectionService {
   static async getBuckets() {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_buckets')
+        .from('collection_buckets')
         .select('*')
         .order('min_days');
 

--- a/src/services/productReportService.js
+++ b/src/services/productReportService.js
@@ -36,7 +36,7 @@ export class ProductReportService {
   static async getProducts() {
     try {
       const { data, error } = await supabaseBanking
-        .from('kastle_banking.products')
+        .from('products')
         .select('product_id, product_name, product_type, product_category, is_active')
         .eq('is_active', true)
         .order('product_name');
@@ -72,7 +72,7 @@ export class ProductReportService {
 
       // Get product info
       const { data: product, error: productError } = await supabaseBanking
-        .from('kastle_banking.products')
+        .from('products')
         .select('*')
         .eq('product_id', productId)
         .single();
@@ -87,7 +87,7 @@ export class ProductReportService {
 
       // Get all loan accounts for the product
       let loansQuery = supabaseBanking
-        .from('kastle_banking.loan_accounts')
+        .from('loan_accounts')
         .select(`
           loan_account_number,
           customer_id,
@@ -99,12 +99,12 @@ export class ProductReportService {
           disbursement_date,
           maturity_date,
           interest_rate,
-          kastle_banking.customers!customer_id (
+          customers!customer_id (
             full_name,
             customer_type,
             branch_id,
             risk_category,
-            kastle_banking.branches!branch_id (
+            branches!branch_id (
               branch_name,
               city,
               region
@@ -115,11 +115,11 @@ export class ProductReportService {
 
       // Apply filters
       if (branch !== 'all') {
-        loansQuery = loansQuery.eq('kastle_banking.customers.branch_id', branch);
+        loansQuery = loansQuery.eq('customers.branch_id', branch);
       }
 
       if (customerType !== 'all') {
-        loansQuery = loansQuery.eq('kastle_banking.customers.customer_type', customerType);
+        loansQuery = loansQuery.eq('customers.customer_type', customerType);
       }
 
       const { data: loans, error: loansError } = await loansQuery;
@@ -130,15 +130,15 @@ export class ProductReportService {
       const loanNumbers = loans?.map(l => l.loan_account_number) || [];
       
       let casesQuery = supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select(`
           *,
-          kastle_collection.collection_interactions!case_id (
+          collection_interactions!case_id (
             interaction_type,
             outcome,
             interaction_datetime
           ),
-          kastle_collection.promise_to_pay!case_id (
+          promise_to_pay!case_id (
             ptp_amount,
             ptp_date,
             status
@@ -344,7 +344,7 @@ export class ProductReportService {
     try {
       // Get all products
       const { data: products, error: productsError } = await supabaseBanking
-        .from('kastle_banking.products')
+        .from('products')
         .select('product_id, product_name, product_type')
         .eq('is_active', true);
 
@@ -416,7 +416,7 @@ export class ProductReportService {
       const caseIds = cases?.map(c => c.case_id) || [];
       
       const { data: interactions, error } = await supabaseCollection
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select('*')
         .in('case_id', caseIds)
         .gte('interaction_datetime', startDate);

--- a/src/services/specialistReportService.js
+++ b/src/services/specialistReportService.js
@@ -13,7 +13,7 @@ class SpecialistReportService {
     try {
       // جلب البيانات من جدول collection_officers
       const { data, error } = await supabaseBanking
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select(`
           officer_id,
           officer_name,
@@ -33,7 +33,7 @@ class SpecialistReportService {
 
       // جلب بيانات الفرق
       const { data: teamsData, error: teamsError } = await supabaseBanking
-        .from('kastle_collection.collection_teams')
+        .from('collection_teams')
         .select('team_id, team_name, team_type');
 
       if (teamsError) {
@@ -135,7 +135,7 @@ class SpecialistReportService {
   async getSpecialistById(specialistId) {
     try {
       const { data, error } = await supabaseBanking
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select(`
           officer_id,
           officer_name,
@@ -161,7 +161,7 @@ class SpecialistReportService {
       // جلب بيانات الفريق
       if (data && data.team_id) {
         const { data: teamData, error: teamError } = await supabaseBanking
-          .from('kastle_collection.collection_teams')
+          .from('collection_teams')
           .select('team_id, team_name, team_type, team_lead_id')
           .eq('team_id', data.team_id)
           .single();
@@ -205,7 +205,7 @@ class SpecialistReportService {
     try {
       // جلب الحالات المخصصة للأخصائي من جدول collection_cases
       let query = supabaseBanking
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select(`
           case_id,
           case_number,
@@ -222,7 +222,7 @@ class SpecialistReportService {
           last_payment_amount,
           last_contact_date,
           next_action_date,
-          kastle_banking.loan_accounts!loan_account_number (
+          loan_accounts!loan_account_number (
             loan_amount,
             outstanding_balance,
             overdue_amount,
@@ -231,21 +231,21 @@ class SpecialistReportService {
             product_id,
             loan_start_date,
             maturity_date,
-            kastle_banking.products!product_id (
+            products!product_id (
               product_name,
               product_type
             )
           ),
-          kastle_banking.customers!customer_id (
+          customers!customer_id (
             full_name,
             customer_type,
             national_id,
-            kastle_banking.customer_contacts!customer_id (
+            customer_contacts!customer_id (
               contact_type,
               contact_value
             )
           ),
-          kastle_collection.collection_buckets!bucket_id (
+          collection_buckets!bucket_id (
             bucket_name,
             min_days,
             max_days
@@ -395,7 +395,7 @@ class SpecialistReportService {
       
       // جلب تفاعلات الأخصائي
       const { data: interactions, error } = await supabaseBanking
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select(`
           interaction_id,
           interaction_type,
@@ -532,7 +532,7 @@ class SpecialistReportService {
       const dateFrom = this.getDateRangeStart(dateRange);
       
       const { data, error } = await supabaseBanking
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .select(`
           ptp_id,
           case_id,
@@ -542,11 +542,11 @@ class SpecialistReportService {
           actual_payment_date,
           actual_payment_amount,
           created_at,
-          kastle_collection.collection_cases!case_id (
+          collection_cases!case_id (
             case_number,
             customer_id,
             loan_account_number,
-            kastle_banking.customers!customer_id (
+            customers!customer_id (
               full_name,
               customer_type
             )
@@ -599,7 +599,7 @@ class SpecialistReportService {
       const dateFrom = this.getDateRangeStart(dateRange);
       
       const { data: performanceData, error } = await supabaseBanking
-        .from('kastle_collection.officer_performance_metrics')
+        .from('officer_performance_metrics')
         .select(`
           metric_date,
           calls_made,
@@ -1077,14 +1077,14 @@ class SpecialistReportService {
     try {
       // جلب آخر التفاعلات
       const { data: recentInteractions } = await supabaseBanking
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select(`
           interaction_type,
           interaction_datetime,
           outcome,
-          kastle_collection.collection_cases!case_id (
+          collection_cases!case_id (
             customer_id,
-            kastle_banking.customers!customer_id (
+            customers!customer_id (
               full_name
             )
           )


### PR DESCRIPTION
Fixes Supabase query errors by configuring schema-specific clients and removing redundant schema prefixes from table names.

Previously, the application used schema-qualified table names (e.g., `kastle_collection.collection_officers`) with a Supabase client that implicitly or explicitly defaulted to the `public` schema. This resulted in queries attempting to access `public.kastle_collection.collection_officers`, leading to "relation does not exist" errors (400/404). This PR resolves the issue by creating dedicated Supabase clients for each schema (`kastle_banking`, `kastle_collection`) and updating all queries to use only the table name, allowing the client's schema configuration to handle the correct routing.

---

[Open in Web](https://cursor.com/agents?id=bc-550e19bc-fe2f-42ad-ba9d-465e5ef206a7) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-550e19bc-fe2f-42ad-ba9d-465e5ef206a7) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)