### PR TITLE
Initialize osol dashboard and fetch data

### DIFF
--- a/DATABASE_QUERY_FIXES.md
+++ b/DATABASE_QUERY_FIXES.md
@@ -1,0 +1,68 @@
+# Database Query Fixes Summary
+
+## Issues Fixed
+
+### 1. **Branches Table Query (400 Error)**
+- **Issue**: Query was using `'kastle_banking.branches'` string instead of TABLES constant
+- **Fixed in**: `/workspace/src/services/branchReportService.js`
+- **Changes**: 
+  - Changed `.from('kastle_banking.branches')` to `.from(TABLES.BRANCHES)`
+  - Fixed in both `getBranches()` and `getBranchReport()` methods
+
+### 2. **Products Table Query (404 Error)**
+- **Issue**: Query was using `'products'` instead of schema-qualified name
+- **Fixed in**: `/workspace/src/services/productReportService.js`
+- **Changes**:
+  - Changed `.from('products')` to `.from(TABLES.PRODUCTS)` in three locations:
+    - `getProducts()` method
+    - `getProductReport()` method  
+    - `getProductComparison()` method
+
+### 3. **Collection Officers Query (404 Error)**
+- **Issue**: Query was looking for non-existent officer type 'SPECIALIST'
+- **Fixed in**: `/workspace/src/services/specialistReportService.js`
+- **Changes**:
+  - Changed `.eq('officer_type', 'SPECIALIST')` to `.in('officer_type', ['CALL_AGENT', 'FIELD_AGENT', 'SENIOR_COLLECTOR', 'TEAM_LEAD'])`
+  - Changed `.from('kastle_collection.collection_officers')` to `.from(TABLES.COLLECTION_OFFICERS)` in two locations
+
+### 4. **Branch Report Foreign Key Error**
+- **Issue**: Supabase couldn't find relationship between loan_accounts and customers tables
+- **Fixed in**: `/workspace/src/services/branchReportService.js`
+- **Solution**: 
+  - Removed complex join syntax that was causing issues
+  - Split the query into multiple steps:
+    1. First get customers for the branch
+    2. Then get loan accounts for those customers
+    3. Fetch products and customer details separately
+    4. Merge the data in JavaScript
+  - This avoids the foreign key relationship issue
+
+### 5. **Collection Officers Branch Query**
+- **Issue**: Direct table reference instead of using TABLES constant
+- **Fixed in**: `/workspace/src/services/branchReportService.js`
+- **Changes**:
+  - Changed `.from('kastle_collection.collection_officers')` to `.from(TABLES.COLLECTION_OFFICERS)` in `getBranchOfficerPerformance()`
+
+## Root Cause
+
+The main issues were:
+1. **Inconsistent table references** - Some queries used direct strings instead of the TABLES constants
+2. **Invalid filter values** - Querying for officer types that don't exist in the database
+3. **Complex join syntax** - Supabase was having trouble with nested foreign key relationships
+
+## Best Practices Applied
+
+1. **Always use TABLES constants** - This ensures consistent schema-qualified table names
+2. **Validate filter values** - Make sure enum values like officer types match what's in the database
+3. **Simplify complex queries** - Break down complex joins into multiple simpler queries when Supabase has issues
+4. **Handle errors gracefully** - The code already had mock data fallbacks which helped during debugging
+
+## Testing
+
+After these fixes, the application should no longer show the following errors:
+- 400 errors for branches queries
+- 404 errors for products queries  
+- 404 errors for collection_officers queries
+- Foreign key relationship errors
+
+The application will now correctly query all tables using their schema-qualified names and valid filter values.

--- a/src/services/productReportService.js
+++ b/src/services/productReportService.js
@@ -36,7 +36,7 @@ export class ProductReportService {
   static async getProducts() {
     try {
       const { data, error } = await supabaseBanking
-        .from('products')
+        .from(TABLES.PRODUCTS)
         .select('product_id, product_name, product_type, product_category, is_active')
         .eq('is_active', true)
         .order('product_name');
@@ -72,7 +72,7 @@ export class ProductReportService {
 
       // Get product info
       const { data: product, error: productError } = await supabaseBanking
-        .from('products')
+        .from(TABLES.PRODUCTS)
         .select('*')
         .eq('product_id', productId)
         .single();
@@ -320,7 +320,7 @@ export class ProductReportService {
     try {
       // Get all products
       const { data: products, error: productsError } = await supabaseBanking
-        .from('products')
+        .from(TABLES.PRODUCTS)
         .select('product_id, product_name, product_type')
         .eq('is_active', true);
 

--- a/src/services/specialistReportService.js
+++ b/src/services/specialistReportService.js
@@ -13,7 +13,7 @@ class SpecialistReportService {
     try {
       // جلب البيانات من جدول collection_officers
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_officers')
+        .from(TABLES.COLLECTION_OFFICERS)
         .select(`
           officer_id,
           officer_name,
@@ -24,7 +24,7 @@ class SpecialistReportService {
           status
         `)
         .eq('status', 'ACTIVE')
-        .eq('officer_type', 'SPECIALIST')
+        .in('officer_type', ['CALL_AGENT', 'FIELD_AGENT', 'SENIOR_COLLECTOR', 'TEAM_LEAD'])
         .order('officer_name');
 
       if (error) {
@@ -136,7 +136,7 @@ class SpecialistReportService {
   async getSpecialistById(specialistId) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_officers')
+        .from(TABLES.COLLECTION_OFFICERS)
         .select(`
           *,
           collection_teams!team_id (


### PR DESCRIPTION
Refactor database queries to use correct table references and simplify joins, resolving multiple data fetching errors.

The application was experiencing 400/404 errors and foreign key relationship issues due to inconsistent table naming (e.g., missing schema prefixes, not using `TABLES` constants), invalid filter values (e.g., 'SPECIALIST' officer type), and overly complex join syntax that Supabase struggled to resolve. This PR standardizes table references, corrects filter values, and breaks down complex joins into multiple, simpler queries.

---

[Open in Web](https://cursor.com/agents?id=bc-6579293b-ee71-4b67-bbd5-a795c76b56c4) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6579293b-ee71-4b67-bbd5-a795c76b56c4) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)