### PR TITLE
Fix database schema errors

### DIFF
--- a/src/components/dashboard/ProductLevelReport.jsx
+++ b/src/components/dashboard/ProductLevelReport.jsx
@@ -567,7 +567,7 @@ const ProductLevelReport = () => {
                                 </div>
                               </div>
                             </TableCell>
-                            <TableCell className="text-center">{branch.region}</TableCell>
+                            <TableCell className="text-center">{branch.state}</TableCell>
                             <TableCell className="text-center">{formatNumber(branch.totalLoans)}</TableCell>
                             <TableCell className="text-center">{formatCurrency(branch.totalAmount)}</TableCell>
                             <TableCell className="text-center">

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -69,14 +69,14 @@ export const TABLES = {
   COLLECTION_AUDIT_TRAIL: 'kastle_collection.audit_trail',
   COLLECTION_CALL_RECORDS: 'kastle_collection.call_records',
   COLLECTION_CAMPAIGNS: 'kastle_collection.collection_campaigns',
-  COLLECTION_CASES: 'kastle_collection.collection_cases',
+  COLLECTION_CASES: 'kastle_banking.collection_cases', // This table is in kastle_banking schema
   COLLECTION_INTERACTIONS: 'kastle_collection.collection_interactions',
   COLLECTION_OFFICERS: 'kastle_collection.collection_officers',
   COLLECTION_SCORES: 'kastle_collection.collection_scores',
   COLLECTION_STRATEGIES: 'kastle_collection.collection_strategies',
   COLLECTION_SYSTEM_PERFORMANCE: 'kastle_collection.system_performance',
   COLLECTION_TEAMS: 'kastle_collection.collection_teams',
-  COLLECTION_BUCKETS: 'kastle_collection.collection_buckets',
+  COLLECTION_BUCKETS: 'kastle_banking.collection_buckets', // This table is in kastle_banking schema
   PROMISE_TO_PAY: 'kastle_collection.promise_to_pay',
   LEGAL_CASES: 'kastle_collection.legal_cases',
   DAILY_COLLECTION_SUMMARY: 'kastle_collection.daily_collection_summary',

--- a/src/services/branchReportService.js
+++ b/src/services/branchReportService.js
@@ -37,7 +37,7 @@ export class BranchReportService {
     try {
       const { data, error } = await supabaseBanking
         .from('kastle_banking.branches')
-        .select('branch_id, branch_name, branch_code, city, region, is_active')
+        .select('branch_id, branch_name, branch_type, city, state, is_active')
         .eq('is_active', true)
         .order('branch_name');
 
@@ -48,11 +48,11 @@ export class BranchReportService {
       console.error('Get branches error:', error);
       // Return mock data if table doesn't exist
       return formatApiResponse([
-        { branch_id: 'BR001', branch_name: 'الرياض - الفرع الرئيسي', branch_code: 'RYD001', city: 'الرياض', region: 'الوسطى' },
-        { branch_id: 'BR002', branch_name: 'جدة - فرع التحلية', branch_code: 'JED001', city: 'جدة', region: 'الغربية' },
-        { branch_id: 'BR003', branch_name: 'الدمام - فرع الملك فهد', branch_code: 'DMM001', city: 'الدمام', region: 'الشرقية' },
-        { branch_id: 'BR004', branch_name: 'مكة المكرمة', branch_code: 'MKH001', city: 'مكة', region: 'الغربية' },
-        { branch_id: 'BR005', branch_name: 'المدينة المنورة', branch_code: 'MDN001', city: 'المدينة', region: 'الغربية' }
+        { branch_id: 'BR001', branch_name: 'الرياض - الفرع الرئيسي', branch_type: 'MAIN', city: 'الرياض', state: 'الوسطى' },
+        { branch_id: 'BR002', branch_name: 'جدة - فرع التحلية', branch_type: 'SUB', city: 'جدة', state: 'الغربية' },
+        { branch_id: 'BR003', branch_name: 'الدمام - فرع الملك فهد', branch_type: 'SUB', city: 'الدمام', state: 'الشرقية' },
+        { branch_id: 'BR004', branch_name: 'مكة المكرمة', branch_type: 'SUB', city: 'مكة', state: 'الغربية' },
+        { branch_id: 'BR005', branch_name: 'المدينة المنورة', branch_type: 'SUB', city: 'المدينة', state: 'الغربية' }
       ]);
     }
   }
@@ -128,7 +128,7 @@ export class BranchReportService {
       const loanNumbers = loans?.map(l => l.loan_account_number) || [];
       
       let casesQuery = supabaseCollection
-        .from('collection_cases')
+        .from(TABLES.COLLECTION_CASES)
         .select(`
           *,
           collection_officers!assigned_to (
@@ -246,7 +246,7 @@ export class BranchReportService {
       const performanceData = await Promise.all((officers || []).map(async (officer) => {
         // Get cases assigned to officer
         const { data: officerCases, error: casesError } = await supabaseCollection
-          .from('collection_cases')
+          .from(TABLES.COLLECTION_CASES)
           .select(`
             case_id,
             total_outstanding,
@@ -323,7 +323,7 @@ export class BranchReportService {
       // Get all branches
       const { data: branches, error: branchesError } = await supabaseBanking
         .from('kastle_banking.branches')
-        .select('branch_id, branch_name, city, region')
+        .select('branch_id, branch_name, city, state')
         .eq('is_active', true);
 
       if (branchesError) throw branchesError;
@@ -333,7 +333,7 @@ export class BranchReportService {
         branchId: branch.branch_id,
         branchName: branch.branch_name,
         city: branch.city,
-        region: branch.region,
+        state: branch.state,
         delinquencyRate: branch.branch_id === branchId ? 
           branchMetrics.delinquencyRate : 
           Math.random() * 10 + 5,
@@ -394,7 +394,7 @@ export class BranchReportService {
       const caseIds = cases?.map(c => c.case_id) || [];
       
       const { data: interactions, error } = await supabaseCollection
-        .from('collection_interactions')
+        .from(TABLES.COLLECTION_INTERACTIONS)
         .select('*')
         .in('case_id', caseIds)
         .gte('interaction_datetime', startDate);

--- a/src/services/collectionService.js
+++ b/src/services/collectionService.js
@@ -275,7 +275,7 @@ export class CollectionService {
 
       // Get payment history
       const { data: payments, error: paymentsError } = await supabaseBanking
-        .from('transactions')
+        .from(TABLES.TRANSACTIONS)
         .select('*')
         .eq('account_number', caseData?.account_number)
         .eq('transaction_type_id', 'LOAN_REPAYMENT')

--- a/src/services/productReportService.js
+++ b/src/services/productReportService.js
@@ -36,8 +36,8 @@ export class ProductReportService {
   static async getProducts() {
     try {
       const { data, error } = await supabaseBanking
-        .from('products')
-        .select('product_id, product_name, product_type, product_category, is_active')
+        .from('kastle_banking.products')
+        .select('product_id, product_name, product_type, category_id, is_active')
         .eq('is_active', true)
         .order('product_name');
 
@@ -48,11 +48,11 @@ export class ProductReportService {
       console.error('Get products error:', error);
       // Return mock data if table doesn't exist
       return formatApiResponse([
-        { product_id: 'PROD001', product_name: 'قرض تورق', product_type: 'Tawarruq', product_category: 'Islamic Finance' },
-        { product_id: 'PROD002', product_name: 'قرض كاش', product_type: 'Cash', product_category: 'Personal Loans' },
-        { product_id: 'PROD003', product_name: 'تمويل سيارات', product_type: 'Auto', product_category: 'Asset Finance' },
-        { product_id: 'PROD004', product_name: 'تمويل عقاري', product_type: 'Real Estate', product_category: 'Mortgage' },
-        { product_id: 'PROD005', product_name: 'بطاقة ائتمان', product_type: 'Credit Card', product_category: 'Cards' }
+        { product_id: 1, product_name: 'قرض تورق', product_type: 'Tawarruq', category_id: 1 },
+        { product_id: 2, product_name: 'قرض كاش', product_type: 'Cash', category_id: 2 },
+        { product_id: 3, product_name: 'تمويل سيارات', product_type: 'Auto', category_id: 3 },
+        { product_id: 4, product_name: 'تمويل عقاري', product_type: 'Real Estate', category_id: 4 },
+        { product_id: 5, product_name: 'بطاقة ائتمان', product_type: 'Credit Card', category_id: 5 }
       ]);
     }
   }
@@ -72,7 +72,7 @@ export class ProductReportService {
 
       // Get product info
       const { data: product, error: productError } = await supabaseBanking
-        .from('products')
+        .from('kastle_banking.products')
         .select('*')
         .eq('product_id', productId)
         .single();
@@ -106,7 +106,7 @@ export class ProductReportService {
       const loanNumbers = loans?.map(l => l.loan_account_number) || [];
       
       let casesQuery = supabaseCollection
-        .from('collection_cases')
+        .from(TABLES.COLLECTION_CASES)
         .select(`
           *,
           collection_interactions!case_id (
@@ -320,7 +320,7 @@ export class ProductReportService {
     try {
       // Get all products
       const { data: products, error: productsError } = await supabaseBanking
-        .from('products')
+        .from('kastle_banking.products')
         .select('product_id, product_name, product_type')
         .eq('is_active', true);
 
@@ -392,7 +392,7 @@ export class ProductReportService {
       const caseIds = cases?.map(c => c.case_id) || [];
       
       const { data: interactions, error } = await supabaseCollection
-        .from('collection_interactions')
+        .from(TABLES.COLLECTION_INTERACTIONS)
         .select('*')
         .in('case_id', caseIds)
         .gte('interaction_datetime', startDate);

--- a/src/services/specialistReportService.js
+++ b/src/services/specialistReportService.js
@@ -33,8 +33,8 @@ class SpecialistReportService {
       }
 
       // جلب بيانات الفرق
-      const { data: teamsData, error: teamsError } = await supabaseBanking
-        .from('collection_teams')
+      const { data: teamsData, error: teamsError } = await supabaseCollection
+        .from(TABLES.COLLECTION_TEAMS)
         .select('team_id, team_name, team_type');
 
       if (teamsError) {
@@ -156,8 +156,8 @@ class SpecialistReportService {
 
       // جلب بيانات الفريق
       if (data && data.team_id) {
-        const { data: teamData, error: teamError } = await supabaseBanking
-          .from('collection_teams')
+        const { data: teamData, error: teamError } = await supabaseCollection
+          .from(TABLES.COLLECTION_TEAMS)
           .select('team_id, team_name, team_type, team_lead_id')
           .eq('team_id', data.team_id)
           .single();


### PR DESCRIPTION
Fix database query errors by correcting table schemas, column names, and mock data.

The application was encountering 400 and 404 errors due to queries referencing incorrect table schemas (e.g., `public.products` instead of `kastle_banking.products`, `kastle_collection.collection_cases` instead of `kastle_banking.collection_cases`) and non-existent columns (e.g., `branch_code`, `region`, `product_category`). This PR updates the queries, constants, and mock data to align with the actual database schema.

---

[Open in Web](https://cursor.com/agents?id=bc-0209c3de-ff85-4713-b784-180b437f594f) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-0209c3de-ff85-4713-b784-180b437f594f) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)