### PR TITLE
Resolve ethereum conflicts and fetch dashboard data

### DIFF
--- a/src/pages/SpecialistReport.jsx
+++ b/src/pages/SpecialistReport.jsx
@@ -13,7 +13,7 @@ class SpecialistReportService {
     try {
       // جلب البيانات من جدول collection_officers
       const { data, error } = await supabaseBanking
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select(`
           officer_id,
           officer_name,
@@ -118,7 +118,7 @@ class SpecialistReportService {
   async getSpecialistById(specialistId) {
     try {
       const { data, error } = await supabaseBanking
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select(`
           officer_id,
           officer_name,
@@ -172,7 +172,7 @@ class SpecialistReportService {
     try {
       // جلب الحالات المخصصة للأخصائي من جدول collection_cases
       let query = supabaseBanking
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select(`
           case_id,
           case_number,
@@ -362,7 +362,7 @@ class SpecialistReportService {
       
       // جلب تفاعلات الأخصائي
       const { data: interactions, error } = await supabaseBanking
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select(`
           interaction_id,
           interaction_type,
@@ -499,7 +499,7 @@ class SpecialistReportService {
       const dateFrom = this.getDateRangeStart(dateRange);
       
       const { data, error } = await supabaseBanking
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .select(`
           ptp_id,
           case_id,
@@ -566,7 +566,7 @@ class SpecialistReportService {
       const dateFrom = this.getDateRangeStart(dateRange);
       
       const { data: performanceData, error } = await supabaseBanking
-        .from('kastle_collection.officer_performance_metrics')
+        .from('officer_performance_metrics')
         .select(`
           metric_date,
           calls_made,
@@ -1044,7 +1044,7 @@ class SpecialistReportService {
     try {
       // جلب آخر التفاعلات
       const { data: recentInteractions } = await supabaseBanking
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select(`
           interaction_type,
           interaction_datetime,

--- a/src/services/collectionService.js
+++ b/src/services/collectionService.js
@@ -52,7 +52,7 @@ export class CollectionService {
 
       // Build query
       let query = supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select(`
           *,
           kastle_banking.loan_accounts!loan_account_number (
@@ -149,13 +149,13 @@ export class CollectionService {
       const enrichedData = await Promise.all((data || []).map(async (caseItem) => {
         // Get interaction count for this case
         const { count: interactionCount } = await supabaseCollection
-          .from('kastle_collection.collection_interactions')
+          .from('collection_interactions')
           .select('interaction_id', { count: 'exact', head: true })
           .eq('case_id', caseItem.case_id);
 
         // Get promise to pay status
         const { data: activePTP } = await supabaseCollection
-          .from('kastle_collection.promise_to_pay')
+          .from('promise_to_pay')
           .select('ptp_id, ptp_date, ptp_amount')
           .eq('case_id', caseItem.case_id)
           .eq('status', 'ACTIVE')
@@ -208,7 +208,7 @@ export class CollectionService {
     try {
       // Get case info with all related data
       const { data: caseData, error: caseError } = await supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select(`
           *,
           kastle_banking.loan_accounts!loan_account_number (
@@ -231,7 +231,7 @@ export class CollectionService {
 
       // Get interactions
       const { data: interactions, error: interactionsError } = await supabaseCollection
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select(`
           *,
           kastle_collection.collection_officers!officer_id (
@@ -244,7 +244,7 @@ export class CollectionService {
 
       // Get promises to pay
       const { data: promisesToPay, error: ptpError } = await supabaseCollection
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .select(`
           *,
           kastle_collection.collection_officers!officer_id (
@@ -256,7 +256,7 @@ export class CollectionService {
 
       // Get field visits
       const { data: fieldVisits, error: visitsError } = await supabaseCollection
-        .from('kastle_collection.field_visits')
+        .from('field_visits')
         .select(`
           *,
           kastle_collection.collection_officers!officer_id (
@@ -268,7 +268,7 @@ export class CollectionService {
 
       // Get legal case if exists
       const { data: legalCase, error: legalError } = await supabaseCollection
-        .from('kastle_collection.legal_cases')
+        .from('legal_cases')
         .select('*')
         .eq('case_id', caseId)
         .single();
@@ -284,7 +284,7 @@ export class CollectionService {
 
       // Get collection score history
       const { data: scoreHistory, error: scoreError } = await supabaseCollection
-        .from('kastle_collection.collection_scores')
+        .from('collection_scores')
         .select('*')
         .eq('case_id', caseId)
         .order('score_date', { ascending: false })
@@ -323,7 +323,7 @@ export class CollectionService {
 
       // Build base query for cases
       let casesQuery = supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select('case_id, total_outstanding, days_past_due, case_status, priority, bucket_id, assigned_to');
 
       // Apply filters
@@ -347,7 +347,7 @@ export class CollectionService {
       let filteredCases = cases || [];
       if (team && team !== 'all') {
         const { data: teamOfficers } = await supabaseCollection
-          .from('kastle_collection.collection_officers')
+          .from('collection_officers')
           .select('officer_id')
           .eq('team_id', team);
         
@@ -366,7 +366,7 @@ export class CollectionService {
       startOfMonth.setHours(0, 0, 0, 0);
 
       const { data: monthlyRecovery } = await supabaseCollection
-        .from('kastle_collection.daily_collection_summary')
+        .from('daily_collection_summary')
         .select('total_collected')
         .gte('summary_date', startOfMonth.toISOString().split('T')[0]);
 
@@ -375,7 +375,7 @@ export class CollectionService {
 
       // Get bucket distribution
       const { data: buckets } = await supabaseCollection
-        .from('kastle_collection.collection_buckets')
+        .from('collection_buckets')
         .select('bucket_id, bucket_name, min_days, max_days');
 
       const bucketDistribution = buckets?.map(bucket => {
@@ -424,7 +424,7 @@ export class CollectionService {
 
       // Get team performance
       const { data: teams } = await supabaseCollection
-        .from('kastle_collection.collection_teams')
+        .from('collection_teams')
         .select(`
           team_id,
           team_name,
@@ -440,7 +440,7 @@ export class CollectionService {
         
         // Get team recovery
         const { data: teamRecovery } = await supabaseCollection
-          .from('kastle_collection.officer_performance_summary')
+          .from('officer_performance_summary')
           .select('total_collected')
           .in('officer_id', teamOfficerIds)
           .gte('summary_date', startOfMonth.toISOString().split('T')[0]);
@@ -515,7 +515,7 @@ export class CollectionService {
 
       // Get daily summaries
       const { data: dailySummaries, error: summaryError } = await supabaseCollection
-        .from('kastle_collection.daily_collection_summary')
+        .from('daily_collection_summary')
         .select('*')
         .gte('summary_date', startDate.toISOString().split('T')[0])
         .lte('summary_date', endDate.toISOString().split('T')[0])
@@ -525,7 +525,7 @@ export class CollectionService {
 
       // Get top officers performance
       const { data: officerPerformance, error: officersError } = await supabaseCollection
-        .from('kastle_collection.officer_performance_summary')
+        .from('officer_performance_summary')
         .select(`
           *,
           kastle_collection.collection_officers!officer_id (
@@ -543,17 +543,17 @@ export class CollectionService {
 
       // Get team comparison
       const { data: teams, error: teamsError } = await supabaseCollection
-        .from('kastle_collection.collection_teams')
+        .from('collection_teams')
         .select('*');
 
       const teamComparison = await Promise.all((teams || []).map(async (team) => {
         const { data: teamData } = await supabaseCollection
-          .from('kastle_collection.officer_performance_summary')
+          .from('officer_performance_summary')
           .select('total_collected, total_cases, contact_rate')
           .eq('summary_date', endDate.toISOString().split('T')[0])
           .in('officer_id', 
             supabaseCollection
-              .from('kastle_collection.collection_officers')
+              .from('collection_officers')
               .select('officer_id')
               .eq('team_id', team.team_id)
           );
@@ -576,7 +576,7 @@ export class CollectionService {
 
       // Get campaign effectiveness
       const { data: campaigns, error: campaignsError } = await supabaseCollection
-        .from('kastle_collection.collection_campaigns')
+        .from('collection_campaigns')
         .select('*')
         .in('status', ['ACTIVE', 'COMPLETED'])
         .order('created_at', { ascending: false })
@@ -584,7 +584,7 @@ export class CollectionService {
 
       // Get channel performance
       const { data: channelPerformance } = await supabaseCollection
-        .from('kastle_collection.digital_collection_attempts')
+        .from('digital_collection_attempts')
         .select('channel_type, payment_made, payment_amount')
         .gte('sent_datetime', startDate.toISOString());
 
@@ -679,7 +679,7 @@ export class CollectionService {
       startDate.setMonth(startDate.getMonth() - (period === 'daily' ? 1 : period === 'weekly' ? 3 : 12));
 
       const { data: trends, error: trendsError } = await supabaseCollection
-        .from('kastle_collection.daily_collection_summary')
+        .from('daily_collection_summary')
         .select('summary_date, total_collected, collection_rate, calls_made, ptps_created, ptps_kept')
         .gte('summary_date', startDate.toISOString().split('T')[0])
         .lte('summary_date', endDate.toISOString().split('T')[0])
@@ -689,7 +689,7 @@ export class CollectionService {
 
       // Get bucket movement analysis
       const { data: bucketMovements, error: bucketError } = await supabaseCollection
-        .from('kastle_collection.case_bucket_history')
+        .from('case_bucket_history')
         .select(`
           from_bucket_id,
           to_bucket_id,
@@ -705,7 +705,7 @@ export class CollectionService {
 
       // Get PTP analysis
       const { data: ptpData, error: ptpError } = await supabaseCollection
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .select('status, ptp_amount, created_at, kept_date, broken_date')
         .gte('created_at', startDate.toISOString());
 
@@ -721,7 +721,7 @@ export class CollectionService {
 
       // Channel effectiveness from digital attempts
       const { data: digitalAttempts } = await supabaseCollection
-        .from('kastle_collection.digital_collection_attempts')
+        .from('digital_collection_attempts')
         .select('channel_type, payment_made, payment_amount, response_received')
         .gte('sent_datetime', startDate.toISOString());
 
@@ -828,7 +828,7 @@ export class CollectionService {
         case 'summary':
           // Get overall collection summary
           const { data: summary } = await supabaseCollection
-            .from('kastle_collection.daily_collection_summary')
+            .from('daily_collection_summary')
             .select('*')
             .gte('summary_date', startDate.toISOString().split('T')[0])
             .lte('summary_date', endDate.toISOString().split('T')[0])
@@ -852,7 +852,7 @@ export class CollectionService {
         case 'detailed':
           // Get detailed collection data by officer
           const { data: officerData } = await supabaseCollection
-            .from('kastle_collection.officer_performance_summary')
+            .from('officer_performance_summary')
             .select(`
               *,
               collection_officers (
@@ -876,7 +876,7 @@ export class CollectionService {
         case 'bucket':
           // Get collection by bucket
           const { data: bucketData } = await supabaseCollection
-            .from('kastle_collection.collection_cases')
+            .from('collection_cases')
             .select(`
               bucket_id,
               total_outstanding,
@@ -923,7 +923,7 @@ export class CollectionService {
         case 'team':
           // Get collection by team
           const { data: teams } = await supabaseCollection
-            .from('kastle_collection.collection_teams')
+            .from('collection_teams')
             .select(`
               *,
               collection_officers (
@@ -936,7 +936,7 @@ export class CollectionService {
             const officerIds = team.kastle_collection?.collection_officers?.map(o => o.officer_id) || [];
             
             const { data: teamData } = await supabaseCollection
-              .from('kastle_collection.officer_performance_summary')
+              .from('officer_performance_summary')
               .select('total_collected, total_cases, contact_rate')
               .in('officer_id', officerIds)
               .gte('summary_date', startDate.toISOString().split('T')[0])
@@ -1001,7 +1001,7 @@ export class CollectionService {
       }
 
       const { data: officerPerformance, error: officersError } = await supabaseCollection
-        .from('kastle_collection.officer_performance_summary')
+        .from('officer_performance_summary')
         .select(`
           *,
           collection_officers (
@@ -1052,7 +1052,7 @@ export class CollectionService {
       }
 
       const { data: teams, error: teamsError } = await supabaseCollection
-        .from('kastle_collection.collection_teams')
+        .from('collection_teams')
         .select(`
           *,
           collection_officers (
@@ -1067,7 +1067,7 @@ export class CollectionService {
         const officerIds = team.kastle_collection?.collection_officers?.map(o => o.officer_id) || [];
         
         const { data: teamData } = await supabaseCollection
-          .from('kastle_collection.officer_performance_summary')
+          .from('officer_performance_summary')
           .select('total_collected, total_cases, contact_rate, ptp_rate')
           .in('officer_id', officerIds)
           .gte('summary_date', startDate.toISOString().split('T')[0])
@@ -1112,7 +1112,7 @@ export class CollectionService {
       const { teamId, officerType, status = 'ACTIVE' } = filters;
 
       let query = supabaseCollection
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select(`
           *,
           collection_teams (
@@ -1151,7 +1151,7 @@ export class CollectionService {
     try {
       // First get the officers
       const { data: officers, error: officersError } = await supabaseCollection
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select(`
           officer_id, 
           officer_name, 
@@ -1172,7 +1172,7 @@ export class CollectionService {
         
         if (teamIds.length > 0) {
           const { data: teams, error: teamsError } = await supabaseCollection
-            .from('kastle_collection.collection_teams')
+            .from('collection_teams')
             .select('team_id, team_name, team_type')
             .in('team_id', teamIds);
 
@@ -1219,7 +1219,7 @@ export class CollectionService {
 
       // Get specialist info
       const { data: specialist, error: specialistError } = await supabaseCollection
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select('*')
         .eq('officer_id', specialistId)
         .single();
@@ -1228,7 +1228,7 @@ export class CollectionService {
 
       // Get cases assigned to specialist with all loan details
       let casesQuery = supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select(`
           *,
           kastle_banking.loan_accounts!loan_account_number (
@@ -1272,7 +1272,7 @@ export class CollectionService {
 
       // Get communication logs for the specialist
       const { data: communicationLogs, error: commError } = await supabaseCollection
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select(`
           *,
           kastle_collection.collection_cases!case_id (
@@ -1286,7 +1286,7 @@ export class CollectionService {
 
       // Get promises to pay
       const { data: promisesToPay, error: ptpError } = await supabaseCollection
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .select(`
           *,
           kastle_collection.collection_cases!case_id (
@@ -1468,7 +1468,7 @@ export class CollectionService {
   static async createCollectionCase(caseData) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .insert([{
           ...caseData,
           case_number: `CASE-${Date.now()}`,
@@ -1482,7 +1482,7 @@ export class CollectionService {
 
       // Create initial collection score
       await supabaseCollection
-        .from('kastle_collection.collection_scores')
+        .from('collection_scores')
         .insert([{
           case_id: data.case_id,
           score_date: new Date().toISOString(),
@@ -1504,7 +1504,7 @@ export class CollectionService {
   static async updateCollectionCase(caseId, updates) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .update({
           ...updates,
           updated_at: new Date().toISOString()
@@ -1528,7 +1528,7 @@ export class CollectionService {
   static async logInteraction(interactionData) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .insert([{
           ...interactionData,
           interaction_datetime: new Date().toISOString()
@@ -1556,7 +1556,7 @@ export class CollectionService {
   static async createPromiseToPay(ptpData) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .insert([{
           ...ptpData,
           status: 'ACTIVE',
@@ -1591,7 +1591,7 @@ export class CollectionService {
       }
 
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .update(updateData)
         .eq('ptp_id', ptpId)
         .select()
@@ -1612,7 +1612,7 @@ export class CollectionService {
   static async scheduleFieldVisit(visitData) {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.field_visits')
+        .from('field_visits')
         .insert([{
           ...visitData,
           status: 'SCHEDULED',
@@ -1788,7 +1788,7 @@ export class CollectionService {
   static async getTeams() {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_teams')
+        .from('collection_teams')
         .select('*')
         .order('team_name');
 
@@ -1807,7 +1807,7 @@ export class CollectionService {
   static async getStrategies() {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_strategies')
+        .from('collection_strategies')
         .select('*')
         .eq('is_active', true)
         .order('strategy_name');
@@ -1827,7 +1827,7 @@ export class CollectionService {
   static async getBuckets() {
     try {
       const { data, error } = await supabaseCollection
-        .from('kastle_collection.collection_buckets')
+        .from('collection_buckets')
         .select('*')
         .order('min_days');
 

--- a/src/services/specialistReportService.js
+++ b/src/services/specialistReportService.js
@@ -13,7 +13,7 @@ class SpecialistReportService {
     try {
       // جلب البيانات من جدول collection_officers
       const { data: officers, error: officersError } = await supabaseBanking
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select(`
           officer_id,
           officer_name,
@@ -37,7 +37,7 @@ class SpecialistReportService {
         
         if (teamIds.length > 0) {
           const { data: teams, error: teamsError } = await supabaseBanking
-            .from('kastle_collection.collection_teams')
+            .from('collection_teams')
             .select('team_id, team_name, team_type')
             .in('team_id', teamIds);
 
@@ -144,7 +144,7 @@ class SpecialistReportService {
   async getSpecialistById(specialistId) {
     try {
       const { data, error } = await supabaseBanking
-        .from('kastle_collection.collection_officers')
+        .from('collection_officers')
         .select(`
           officer_id,
           officer_name,
@@ -198,7 +198,7 @@ class SpecialistReportService {
     try {
       // جلب الحالات المخصصة للأخصائي من جدول collection_cases
       let query = supabaseBanking
-        .from('kastle_collection.collection_cases')
+        .from('collection_cases')
         .select(`
           case_id,
           case_number,
@@ -388,7 +388,7 @@ class SpecialistReportService {
       
       // جلب تفاعلات الأخصائي
       const { data: interactions, error } = await supabaseBanking
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select(`
           interaction_id,
           interaction_type,
@@ -525,7 +525,7 @@ class SpecialistReportService {
       const dateFrom = this.getDateRangeStart(dateRange);
       
       const { data, error } = await supabaseBanking
-        .from('kastle_collection.promise_to_pay')
+        .from('promise_to_pay')
         .select(`
           ptp_id,
           case_id,
@@ -592,7 +592,7 @@ class SpecialistReportService {
       const dateFrom = this.getDateRangeStart(dateRange);
       
       const { data: performanceData, error } = await supabaseBanking
-        .from('kastle_collection.officer_performance_metrics')
+        .from('officer_performance_metrics')
         .select(`
           metric_date,
           calls_made,
@@ -1070,7 +1070,7 @@ class SpecialistReportService {
     try {
       // جلب آخر التفاعلات
       const { data: recentInteractions } = await supabaseBanking
-        .from('kastle_collection.collection_interactions')
+        .from('collection_interactions')
         .select(`
           interaction_type,
           interaction_datetime,


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove redundant schema prefixes from Supabase queries to fix 404 errors.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Supabase queries were failing because they included the `kastle_collection.` schema prefix (e.g., `supabase.from('kastle_collection.table')`) even though the Supabase client was already configured for this schema. This resulted in an incorrect table path (e.g., `kastle_collection.kastle_collection.table`) and a 404 error. This PR removes these redundant prefixes, allowing queries to correctly access tables.

---

[Open in Web](https://cursor.com/agents?id=bc-b1729b5c-1d0f-4918-8397-8725bebaecba) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b1729b5c-1d0f-4918-8397-8725bebaecba) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)