### PR TITLE
Resolve ethereum conflict and fetch dashboard data

### DIFF
--- a/COLLECTION_OFFICERS_FIX.md
+++ b/COLLECTION_OFFICERS_FIX.md
@@ -1,0 +1,39 @@
+# Collection Officers Table Fix Summary
+
+## Issue
+The application was throwing the error:
+```
+Error fetching specialists: column collection_officers.officer_name does not exist
+```
+
+## Root Cause
+The issue was that the queries were trying to access tables without specifying the schema prefix. The `collection_officers` table exists in the `kastle_collection` schema, but the queries were not using the schema-qualified table names.
+
+## Fixes Applied
+
+### 1. Fixed specialistReportService.js
+Updated all table references to include the schema prefix:
+- `collection_officers` → `kastle_collection.collection_officers`
+- `collection_teams` → `kastle_collection.collection_teams`
+- `collection_cases` → `kastle_collection.collection_cases`
+- `collection_interactions` → `kastle_collection.collection_interactions`
+- `promise_to_pay` → `kastle_collection.promise_to_pay`
+- `officer_performance_metrics` → `kastle_collection.officer_performance_metrics`
+
+### 2. Fixed collectionService.js
+Updated the `getSpecialists()` function to use the TABLES constants:
+- `'collection_officers'` → `TABLES.COLLECTION_OFFICERS`
+- `'collection_teams'` → `TABLES.COLLECTION_TEAMS`
+
+## Verification
+The table structure confirms that `officer_name` column exists:
+```sql
+create table kastle_collection.collection_officers (
+  officer_id character varying(20) not null,
+  officer_name character varying(200) not null,
+  -- other columns...
+)
+```
+
+## Result
+The error should now be resolved as all queries are properly using schema-qualified table names.

--- a/src/services/collectionService.js
+++ b/src/services/collectionService.js
@@ -1151,7 +1151,7 @@ export class CollectionService {
     try {
       // First get the officers
       const { data: officers, error: officersError } = await supabaseCollection
-        .from('collection_officers')
+        .from(TABLES.COLLECTION_OFFICERS)
         .select(`
           officer_id, 
           officer_name, 
@@ -1172,7 +1172,7 @@ export class CollectionService {
         
         if (teamIds.length > 0) {
           const { data: teams, error: teamsError } = await supabaseCollection
-            .from('collection_teams')
+            .from(TABLES.COLLECTION_TEAMS)
             .select('team_id, team_name, team_type')
             .in('team_id', teamIds);
 

--- a/src/services/specialistReportService.js
+++ b/src/services/specialistReportService.js
@@ -13,7 +13,7 @@ class SpecialistReportService {
     try {
       // جلب البيانات من جدول collection_officers
       const { data: officers, error: officersError } = await supabaseBanking
-        .from('collection_officers')
+        .from('kastle_collection.collection_officers')
         .select(`
           officer_id,
           officer_name,
@@ -37,7 +37,7 @@ class SpecialistReportService {
         
         if (teamIds.length > 0) {
           const { data: teams, error: teamsError } = await supabaseBanking
-            .from('collection_teams')
+            .from('kastle_collection.collection_teams')
             .select('team_id, team_name, team_type')
             .in('team_id', teamIds);
 
@@ -144,7 +144,7 @@ class SpecialistReportService {
   async getSpecialistById(specialistId) {
     try {
       const { data, error } = await supabaseBanking
-        .from('collection_officers')
+        .from('kastle_collection.collection_officers')
         .select(`
           officer_id,
           officer_name,
@@ -198,7 +198,7 @@ class SpecialistReportService {
     try {
       // جلب الحالات المخصصة للأخصائي من جدول collection_cases
       let query = supabaseBanking
-        .from('collection_cases')
+        .from('kastle_collection.collection_cases')
         .select(`
           case_id,
           case_number,
@@ -388,7 +388,7 @@ class SpecialistReportService {
       
       // جلب تفاعلات الأخصائي
       const { data: interactions, error } = await supabaseBanking
-        .from('collection_interactions')
+        .from('kastle_collection.collection_interactions')
         .select(`
           interaction_id,
           interaction_type,
@@ -525,7 +525,7 @@ class SpecialistReportService {
       const dateFrom = this.getDateRangeStart(dateRange);
       
       const { data, error } = await supabaseBanking
-        .from('promise_to_pay')
+        .from('kastle_collection.promise_to_pay')
         .select(`
           ptp_id,
           case_id,
@@ -592,7 +592,7 @@ class SpecialistReportService {
       const dateFrom = this.getDateRangeStart(dateRange);
       
       const { data: performanceData, error } = await supabaseBanking
-        .from('officer_performance_metrics')
+        .from('kastle_collection.officer_performance_metrics')
         .select(`
           metric_date,
           calls_made,
@@ -1070,7 +1070,7 @@ class SpecialistReportService {
     try {
       // جلب آخر التفاعلات
       const { data: recentInteractions } = await supabaseBanking
-        .from('collection_interactions')
+        .from('kastle_collection.collection_interactions')
         .select(`
           interaction_type,
           interaction_datetime,


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes "column does not exist" errors by adding schema prefixes to table names in Supabase queries.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The database tables, such as `collection_officers`, reside within the `kastle_collection` schema. Previously, queries were attempting to access these tables without specifying the schema (e.g., `from('collection_officers')`), causing Supabase to fail in locating the columns. This PR updates the queries to use schema-qualified names (e.g., `from('kastle_collection.collection_officers')`) or leverages existing schema-qualified constants to ensure correct table resolution.

---

[Open in Web](https://cursor.com/agents?id=bc-6a78a364-603b-4466-b2a0-e7f59c24847a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-6a78a364-603b-4466-b2a0-e7f59c24847a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)