### PR TITLE
Fix vercel function runtime version error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -42,11 +42,6 @@
     "VITE_DEV_MODE": "false",
     "VITE_LOG_LEVEL": "error",
     "NODE_ENV": "production"
-  },
-  "functions": {
-    "app/api/**/*.js": {
-      "runtime": "nodejs18.x"
-    }
   }
 }
 


### PR DESCRIPTION
Remove unnecessary `functions` configuration from `vercel.json` to fix Vercel deployment error.

The Vercel deployment failed with "Error: Function Runtimes must have a valid version" because `vercel.json` contained a `functions` block with an incorrect runtime format for non-existent API functions. As this is a static Vite application, the `functions` configuration was removed entirely.

---

[Open in Web](https://cursor.com/agents?id=bc-810278f2-5a52-4b13-ab20-42abdeb3c7dd) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-810278f2-5a52-4b13-ab20-42abdeb3c7dd) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)