### PR TITLE
Fix sidebar rtl alignment for arabic language

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -439,7 +439,7 @@ body {
   height: 20px;
   bottom: 0;
   right: 0;
-  background: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNiIgaGVpZ2h0PSI2IiB2aWV3Qm94PSIwIDAgNiA2IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8ZG90cyBmaWxsPSIjODg4IiBkPSJtMTUgMTJjMCAuNTUyLS40NDggMS0xIDFzLTEtLjQ0OC0xLTEgLjQ0OC0xIDEtMSAxIC40NDggMSAxem0wIDRjMCAuNTUyLS40NDggMS0xIDFzLTEtLjQ0OC0xLTEgLjQ0OC0xIDEtMSAxIC40NDggMSAxem0wIDRjMCAuNTUyLS40NDggMS0xIDFzLTEtLjQ0OC0xLTEgLjQ0OC0xIDEtMSAxIC40NDggMSAxem0tNS0xMGMwIC41NTItLjQ0OCAxLTEgMXMtMS0uNDQ4LTEtMSAuNDQ4LTEgMS0xIDEgLjQ0OCAxIDFabTAgNGMwIC41NTItLjQ0OCAxLTEgMXMtMS0uNDQ4LTEtMSAuNDQ4LTEgMS0xIDEgLjQ0OCAxIDFabTAgNGMwIC41NTItLjQ0OCAxLTEgMXMtMS0uNDQ4LTEtMSAuNDQ4LTEgMS0xIDEgLjQ0OCAxIDFabS01LTEwYzAgLjU1Mi0uNDQ4IDEtMSAxcy0xLS40NDgtMS0xIC40NDgtMSAxLTEgMSAuNDQ4IDEgMVptMCA0YzAgLjU1Mi0uNDQ4IDEtMSAxcy0xLS40NDgtMS0xIC40NDgtMSAxLTEgMSAuNDQ4IDEgMVptMCA0YzAgLjU1Mi0uNDQ4IDEtMSAxcy0xLS40NDgtMS0xIC40NDgtMSAxLTEgMSAuNDQ4IDEgMVoiLz4KPHN2Zz4K');
+  background: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNiIgaGVpZ2h0PSI2IiB2aWV3Qm94PSIwIDAgNiA2IiBmaWxsPSJub25lIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPgo8ZG90cyBmaWxsPSIjODg4IiBkPSJtMTUgMTJjMCAuNTUyLS40NDggMS0xIDFzLTEtLjQ0OC0xLTEgLjQ0OC0xIDEtMSAxIC40NDggMSAxem0wIDRjMCAuNTUyLS40NDggMS0xIDFzLTEtLjQ0OC0xLTEgLjQ0OC0xIDEtMSAxIC40NDggMSAxem0wIDRjMCAuNTUyLS40NDggMS0xIDFzLTEtLjQ0OC0xLTEgLjQ0OC0xIDEtMSAxIC40NDggMSAxem0tNS0xMGMwIC41NTItLjQ0OCAxLTEgMXMtMS0uNDQ4LTEtMSAuNDQ4LTEgMS0xIDEgLjQ0OCAxIDFabTAgNGMwIC41NTItLjQ0OCAxLTEgMXMtMS0uNDQ4LTEtMSAuNDQ4LTEgMS0xIDEgLjQ0OCAxIDFabTAgNGMwIC41NTItLjQ0OCAxLTEgMXMtMS0uNDQ4LTEtMSAuNDQ4LTEgMS0xIDEgLjQ0OCAxIDFabS01LTEwYzAgLjU1Mi0uNDQ4IDEtMSAxcy0xLS40NDgtMS0xIC40NDgtMSAxLTEgMSAuNDQ4IDEgMVptMCA0YzAgLjU1Mi0uNDQ4IDEtMSAxcy0xLS40NDgtMS0xIC40NDgtMSAxLTEgMSAuNDQ4IDEgMVoiLz4KPHN2Zz4K');
   background-position: bottom right;
   padding: 0 3px 3px 0;
   background-repeat: no-repeat;
@@ -477,4 +477,28 @@ body {
   .chart-container {
     break-inside: avoid;
   }
+}
+
+/* Global Styles */
+* {
+  box-sizing: border-box;
+}
+
+/* Ensure RTL is properly applied to the root layout */
+[dir="rtl"] #root > div {
+  flex-direction: row-reverse;
+}
+
+/* Fix for flex containers in RTL */
+[dir="rtl"] .flex:not(.flex-col):not(.flex-column) {
+  flex-direction: row-reverse;
+}
+
+[dir="rtl"] .flex-row {
+  flex-direction: row-reverse !important;
+}
+
+/* Main layout container specific fix */
+[dir="rtl"] body > #root > div:first-child {
+  flex-direction: row-reverse !important;
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import BranchReportPage from '@/pages/collection/BranchReport';
 import ProductReportPage from '@/pages/collection/ProductReport';
 import { Toaster } from './components/ui/sonner';
 import { useTranslation } from 'react-i18next';
+import { RTLDebug } from './components/RTLDebug';
 import 'react-grid-layout/css/styles.css';
 import 'react-resizable/css/styles.css';
 import './App.css';
@@ -162,13 +163,18 @@ function NotFound() {
 function SafeApp() {
   const { i18n } = useTranslation();
   
-  // Database connection status logging
+  // Database connection status logging and RTL setup
   useEffect(() => {
     if (import.meta.env.DEV) {
       console.log('🔗 Checking database connection status...');
       // Connection status is already logged in supabase.js
     }
-  }, []);
+    
+    // Ensure document direction is set on mount
+    const currentLang = i18n.language || 'en';
+    document.documentElement.dir = currentLang === 'ar' ? 'rtl' : 'ltr';
+    document.documentElement.lang = currentLang;
+  }, [i18n.language]);
   
   return (
     <div className={`app ${i18n.language === 'ar' ? 'rtl' : 'ltr'}`} dir={i18n.language === 'ar' ? 'rtl' : 'ltr'}>
@@ -264,6 +270,7 @@ function SafeApp() {
           </Routes>
         </Layout>
         <Toaster />
+        <RTLDebug />
       </Router>
     </div>
   );

--- a/src/components/RTLDebug.jsx
+++ b/src/components/RTLDebug.jsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'react-i18next';
+import { useRTL } from '@/hooks/useRTL';
+
+export function RTLDebug() {
+  const { i18n } = useTranslation();
+  const isRTL = useRTL();
+  
+  return (
+    <div style={{
+      position: 'fixed',
+      bottom: 10,
+      left: 10,
+      background: 'rgba(0,0,0,0.8)',
+      color: 'white',
+      padding: '10px',
+      borderRadius: '5px',
+      fontSize: '12px',
+      zIndex: 9999
+    }}>
+      <div>Language: {i18n.language}</div>
+      <div>RTL: {isRTL ? 'Yes' : 'No'}</div>
+      <div>HTML dir: {document.documentElement.dir || 'not set'}</div>
+      <div>HTML lang: {document.documentElement.lang || 'not set'}</div>
+    </div>
+  );
+}

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -30,8 +30,8 @@ export function Layout({ children }) {
   return (
     <div className={cn(
       "flex h-screen overflow-hidden bg-gray-50 dark:bg-gray-950",
-      isRTL && "flex-row-reverse"
-    )}>
+      isRTL ? "flex-row-reverse" : "flex-row"
+    )} dir={isRTL ? "rtl" : "ltr"}>
       {/* Desktop Sidebar */}
       {!isMobile && (
         <Sidebar isCollapsed={isSidebarCollapsed} setIsCollapsed={setIsSidebarCollapsed} />

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { changeLanguage } from '@/i18n/i18n';
 import { 
   LayoutDashboard, 
   Users, 
@@ -808,7 +809,7 @@ export const Sidebar = ({ isCollapsed, setIsCollapsed }) => {
                   variant="ghost"
                   size="sm"
                   className="h-9 w-full rounded-lg hover:bg-primary/10"
-                  onClick={() => i18n.changeLanguage(i18n.language === 'ar' ? 'en' : 'ar')}
+                  onClick={() => changeLanguage(i18n.language === 'ar' ? 'en' : 'ar')}
                 >
                   <Languages className="h-4 w-4" />
                   {!isCollapsed && <span className="sr-only">Language</span>}

--- a/src/index.css
+++ b/src/index.css
@@ -212,3 +212,20 @@ main {
 .compact-mode .card-content {
   @apply pb-4 pt-2;
 }
+
+/* Force RTL layout for main container */
+[dir="rtl"] .flex.h-screen.overflow-hidden.bg-gray-50,
+[dir="rtl"] .flex.h-screen.overflow-hidden.dark\:bg-gray-950 {
+  flex-direction: row-reverse !important;
+}
+
+/* Ensure sidebar is on the right in RTL */
+[dir="rtl"] aside,
+[dir="rtl"] .sidebar {
+  order: 2;
+}
+
+/* Ensure main content is on the left in RTL */
+[dir="rtl"] .flex-1.flex.flex-col.min-w-0 {
+  order: 1;
+}

--- a/src/styles/rtl-enhanced.css
+++ b/src/styles/rtl-enhanced.css
@@ -6,6 +6,24 @@
   text-align: right;
 }
 
+/* Main Layout Container - Ensure proper RTL flex direction */
+[dir="rtl"] .flex {
+  direction: rtl;
+}
+
+/* Sidebar Positioning for RTL */
+[dir="rtl"] .sidebar,
+[dir="rtl"] aside {
+  order: 2;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+/* Main Content Area in RTL */
+[dir="rtl"] main {
+  order: 1;
+}
+
 /* Flexbox Direction Fixes */
 [dir="rtl"] .flex-row {
   flex-direction: row-reverse;
@@ -297,6 +315,21 @@
 [dir="rtl"] [data-sheet-side="right"] {
   left: 0;
   right: auto;
+}
+
+/* Specific fix for the main layout container */
+[dir="rtl"] .flex.h-screen.overflow-hidden {
+  flex-direction: row-reverse !important;
+}
+
+/* Ensure all direct flex children in main layout respect RTL */
+[dir="rtl"] #root > div.flex {
+  flex-direction: row-reverse !important;
+}
+
+/* Fix for any flex container that should reverse in RTL */
+[dir="rtl"] .flex:not(.flex-col):not(.flex-column):not(.flex-wrap) {
+  flex-direction: row-reverse;
 }
 
 /* Dialog and Modal alignments */


### PR DESCRIPTION
Implement comprehensive RTL layout support to correctly position the sidebar and apply right-to-left styling when the language is set to Arabic.

The previous implementation did not fully apply RTL styles, causing the sidebar to remain on the left and general layout issues when switching to Arabic. This fix involves ensuring the correct language change function is used, explicitly setting `dir` attributes on layout components, and adding comprehensive CSS rules to correctly reverse flex directions and element order for RTL layouts. A temporary `RTLDebug` component was added to `App.jsx` for verification and should be removed after review.

---

[Open in Web](https://cursor.com/agents?id=bc-2d1e1be8-06a0-4f87-90dc-8da40e5b4448) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-2d1e1be8-06a0-4f87-90dc-8da40e5b4448) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)