### PR TITLE
Fix database connection and ethereum conflicts

### DIFF
--- a/DATABASE_QUERY_FIX_SUMMARY.md
+++ b/DATABASE_QUERY_FIX_SUMMARY.md
@@ -1,0 +1,88 @@
+# Database Query Fix Summary
+
+## Issues Fixed
+
+### 1. Foreign Key Relationship Errors
+**Problem**: Supabase queries were failing with errors like:
+```
+"Could not find a relationship between 'collection_cases' and 'collection_officers' in the schema cache"
+```
+
+**Root Cause**: 
+- The `collection_cases` table is in the `kastle_banking` schema
+- The `collection_officers` table is in the `kastle_collection` schema
+- Cross-schema foreign key relationships were not properly configured in Supabase
+
+**Solution Applied**:
+- Replaced complex join queries with separate queries
+- Manually enriched data by fetching related records separately
+- Created lookup maps to associate related data
+
+### 2. Files Updated
+
+#### `/workspace/src/services/branchReportService.js`
+- Fixed `getBranchReport` method to use separate queries instead of foreign key joins
+- Changed from `supabaseCollection` to `supabaseBanking` for `collection_cases` table
+- Added data enrichment logic to manually join related data
+
+#### `/workspace/src/services/productReportService.js`
+- Fixed `getProductReport` method with similar approach
+- Updated all references to use enriched data instead of raw cases
+
+#### `/workspace/src/services/collectionService.js`
+- Fixed `getCaseDetails` method to fetch related data separately
+- Added comprehensive data enrichment for all related tables
+
+### 3. Ethereum Provider Conflict
+**Problem**: Multiple crypto wallet extensions trying to inject `window.ethereum`
+
+**Solution Applied** in `/workspace/public/ethereum-conflict-resolver.js`:
+- Pre-defined the ethereum property before extensions load
+- Enhanced error handling to prevent property redefinition errors
+- Added logic to accept the first provider and ignore subsequent attempts
+
+## Query Pattern Changes
+
+### Before (Failing):
+```javascript
+const { data: cases } = await supabaseCollection
+  .from('collection_cases')
+  .select(`
+    *,
+    collection_officers!assigned_to (officer_id, officer_name),
+    collection_interactions!case_id (*)
+  `);
+```
+
+### After (Working):
+```javascript
+// 1. Get main data
+const { data: cases } = await supabaseBanking
+  .from('collection_cases')
+  .select('*');
+
+// 2. Get related data separately
+const officerIds = [...new Set(cases.map(c => c.assigned_to))];
+const { data: officers } = await supabaseCollection
+  .from('collection_officers')
+  .select('*')
+  .in('officer_id', officerIds);
+
+// 3. Enrich data manually
+const enrichedCases = cases.map(c => ({
+  ...c,
+  assigned_officer: officers.find(o => o.officer_id === c.assigned_to)
+}));
+```
+
+## Benefits
+1. Queries now work reliably without foreign key errors
+2. Better error handling and fallback behavior
+3. More maintainable code with clear data flow
+4. Ethereum provider conflicts resolved
+
+## Testing Required
+- Test branch reports functionality
+- Test product reports functionality
+- Test collection case details view
+- Verify ethereum wallet extensions work without errors


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor Supabase queries to resolve foreign key relationship errors and enhance Ethereum provider conflict resolution.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The application was encountering `PGRST200` errors related to "Could not find a relationship between 'collection_cases' and 'collection_officers' in the schema cache". This was due to Supabase's PostgREST failing to correctly interpret cross-schema foreign key relationships when using the `!hint` syntax. The solution involves fetching related data through separate queries and manually enriching the main dataset, ensuring robust data retrieval.

Additionally, the `Uncaught TypeError: Cannot redefine property: ethereum` error was caused by multiple browser extensions attempting to define `window.ethereum`. The enhanced resolver now pre-defines `window.ethereum` to prevent this redefinition error and gracefully handles subsequent attempts to set the property, ensuring only the first valid provider is used.

---

[Open in Web](https://cursor.com/agents?id=bc-8b2fd1e3-b1ae-4825-ac7e-a8aff158ad49) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-8b2fd1e3-b1ae-4825-ac7e-a8aff158ad49) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)