### PR TITLE
Fix vintage-analysis dashboard trendingdown error

### DIFF
--- a/VINTAGE_ANALYSIS_FIX_SUMMARY.md
+++ b/VINTAGE_ANALYSIS_FIX_SUMMARY.md
@@ -1,0 +1,38 @@
+# Vintage Analysis Dashboard Fix Summary
+
+## Issue
+The vintage analysis dashboard was throwing a runtime error:
+```
+ReferenceError: TrendingDown is not defined
+```
+
+## Root Cause
+The `TrendingDown` icon component from `lucide-react` was being used in the VintageAnalysisDashboard.tsx file without being imported.
+
+## Solution Applied
+
+1. **Fixed Missing Import**: Added `TrendingDown` to the imports in `/workspace/src/pages/VintageAnalysisDashboard.tsx`:
+   ```typescript
+   import { 
+     TrendingUp, TrendingDown, Calendar, DollarSign, AlertTriangle, Activity,
+     BarChart3, PieChart, Target, Clock, Layers, Filter,
+     Download, ChevronDown, Info, ArrowUpRight, ArrowDownRight
+   } from 'lucide-react';
+   ```
+
+2. **Fixed Missing Dependency**: Installed the missing `@hello-pangea/dnd` package that was causing build failures:
+   ```bash
+   pnpm add @hello-pangea/dnd
+   ```
+
+## Database Configuration
+The database connection string provided (`postgresql://postgres:OSOL1a159753@db.bzlenegoilnswsbanxgb.supabase.co:5432/postgres`) is already properly configured in the environment files:
+- `.env` file contains the correct `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY`
+- `DATABASE_URL` is also properly set
+
+## Build Status
+✅ The project now builds successfully without errors
+✅ The vintage analysis dashboard should now work without the `TrendingDown is not defined` error
+
+## Deployment
+The fixed code is ready to be deployed to Vercel. The build process completes successfully with all dependencies properly resolved.

--- a/dist/index.html
+++ b/dist/index.html
@@ -1,21 +1,21 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" dir="ltr">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Osol Dashboard - أصول الحديثة للتمويل</title>
+    <title>Osol Dashboard - Modern Finance Solutions</title>
     <!-- Google Fonts for Arabic support -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@300;400;500;600;700&family=Tajawal:wght@300;400;500;700&family=Cairo:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Ethereum conflict resolver - must be loaded first -->
     <script src="/ethereum-conflict-resolver.js"></script>
-    <script type="module" crossorigin src="/assets/index-CMgtZbuf.js"></script>
-    <link rel="modulepreload" crossorigin href="/assets/lucide-1oFnzLij.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-Bhtw_S50.css">
+    <script type="module" crossorigin src="/assets/index-Bz8G5LKt.js"></script>
+    <link rel="modulepreload" crossorigin href="/assets/lucide-AFGdBtkm.js">
+    <link rel="stylesheet" crossorigin href="/assets/index-Gra_k5EK.css">
   </head>
-  <body>
+  <body dir="ltr">
     <div id="root"></div>
   </body>
 </html>

--- a/node_modules/.bin/acorn
+++ b/node_modules/.bin/acorn
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/acorn@8.14.1/node_modules/acorn/bin/node_modules:/workspace/node_modules/.pnpm/acorn@8.14.1/node_modules/acorn/node_modules:/workspace/node_modules/.pnpm/acorn@8.14.1/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../acorn/bin/acorn" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/acorn@8.14.1/node_modules/acorn/bin/acorn" "$@"
 else
-  exec node  "$basedir/../acorn/bin/acorn" "$@"
+  exec node  "$basedir/../.pnpm/acorn@8.14.1/node_modules/acorn/bin/acorn" "$@"
 fi

--- a/node_modules/.bin/autoprefixer
+++ b/node_modules/.bin/autoprefixer
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/autoprefixer" "$@"
 else
-  exec node  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
+  exec node  "$basedir/../.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/autoprefixer" "$@"
 fi

--- a/node_modules/.bin/browserslist
+++ b/node_modules/.bin/browserslist
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/browserslist@4.24.5/node_modules/browserslist/node_modules:/workspace/node_modules/.pnpm/browserslist@4.24.5/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../browserslist/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/browserslist@4.24.5/node_modules/browserslist/cli.js" "$@"
 else
-  exec node  "$basedir/../browserslist/cli.js" "$@"
+  exec node  "$basedir/../.pnpm/browserslist@4.24.5/node_modules/browserslist/cli.js" "$@"
 fi

--- a/node_modules/.bin/eslint
+++ b/node_modules/.bin/eslint
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../eslint/bin/eslint.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/eslint.js" "$@"
 else
-  exec node  "$basedir/../eslint/bin/eslint.js" "$@"
+  exec node  "$basedir/../.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/eslint.js" "$@"
 fi

--- a/node_modules/.bin/jiti
+++ b/node_modules/.bin/jiti
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/jiti@2.4.2/node_modules/jiti/lib/node_modules:/workspace/node_modules/.pnpm/jiti@2.4.2/node_modules/jiti/node_modules:/workspace/node_modules/.pnpm/jiti@2.4.2/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../jiti/lib/jiti-cli.mjs" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/jiti@2.4.2/node_modules/jiti/lib/jiti-cli.mjs" "$@"
 else
-  exec node  "$basedir/../jiti/lib/jiti-cli.mjs" "$@"
+  exec node  "$basedir/../.pnpm/jiti@2.4.2/node_modules/jiti/lib/jiti-cli.mjs" "$@"
 fi

--- a/node_modules/.bin/tailwind
+++ b/node_modules/.bin/tailwind
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 else
-  exec node  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec node  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 fi

--- a/node_modules/.bin/tailwindcss
+++ b/node_modules/.bin/tailwindcss
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 else
-  exec node  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec node  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 fi

--- a/node_modules/.bin/vite
+++ b/node_modules/.bin/vite
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../vite/bin/vite.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/vite.js" "$@"
 else
-  exec node  "$basedir/../vite/bin/vite.js" "$@"
+  exec node  "$basedir/../.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/vite.js" "$@"
 fi

--- a/node_modules/.bin/yaml
+++ b/node_modules/.bin/yaml
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/yaml@2.8.0/node_modules/yaml/node_modules:/workspace/node_modules/.pnpm/yaml@2.8.0/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../yaml/bin.mjs" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/yaml@2.8.0/node_modules/yaml/bin.mjs" "$@"
 else
-  exec node  "$basedir/../yaml/bin.mjs" "$@"
+  exec node  "$basedir/../.pnpm/yaml@2.8.0/node_modules/yaml/bin.mjs" "$@"
 fi

--- a/node_modules/.pnpm-workspace-state.json
+++ b/node_modules/.pnpm-workspace-state.json
@@ -1,5 +1,5 @@
 {
-  "lastValidatedTimestamp": 1753694433825,
+  "lastValidatedTimestamp": 1753695806706,
   "projects": {},
   "pnpmfileExists": false,
   "settings": {

--- a/src/pages/VintageAnalysisDashboard.tsx
+++ b/src/pages/VintageAnalysisDashboard.tsx
@@ -12,7 +12,7 @@ import {
   Cell, ScatterChart, Scatter, ComposedChart
 } from 'recharts';
 import { 
-  TrendingUp, Calendar, DollarSign, AlertTriangle, Activity,
+  TrendingUp, TrendingDown, Calendar, DollarSign, AlertTriangle, Activity,
   BarChart3, PieChart, Target, Clock, Layers, Filter,
   Download, ChevronDown, Info, ArrowUpRight, ArrowDownRight
 } from 'lucide-react';


### PR DESCRIPTION
Fixes `TrendingDown is not defined` error in Vintage Analysis Dashboard by importing the icon and resolves build issues by installing a missing dependency.

The `TrendingDown` icon was used in `VintageAnalysisDashboard.tsx` without being imported from `lucide-react`, leading to a runtime `ReferenceError`. Additionally, a subsequent build failed due to a missing `@hello-pangea/dnd` package, which was installed to ensure successful builds.

---

[Open in Web](https://cursor.com/agents?id=bc-4e7fc8a4-cd09-4107-834b-c4ea49eae853) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-4e7fc8a4-cd09-4107-834b-c4ea49eae853) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)