### PR TITLE
Fix sidebar auto-close on mobile

### DIFF
--- a/MOBILE_SIDEBAR_FIX_APPLIED.md
+++ b/MOBILE_SIDEBAR_FIX_APPLIED.md
@@ -1,0 +1,59 @@
+# Mobile Sidebar Fix Applied
+
+## Issue
+The mobile sidebar was closing immediately after opening, making it impossible to use navigation on mobile devices.
+
+## Root Cause
+The `useEffect` hook in the Sidebar component was triggering immediately when the sidebar opened on mobile, causing it to close right away. The effect was running on every render when `isMobile` was true, not just on actual navigation.
+
+## Solution Applied
+
+### 1. Added `isMobileSheet` prop to Sidebar component
+```jsx
+export const Sidebar = ({ isCollapsed, setIsCollapsed, isMobileSheet = false }) => {
+```
+
+### 2. Fixed the navigation closing logic
+Changed from:
+```jsx
+useEffect(() => {
+  if (isMobile && typeof setIsCollapsed === 'function') {
+    const handleNavigation = () => {
+      if (window.innerWidth < 768) {
+        setIsCollapsed(true);
+      }
+    };
+    const timer = setTimeout(handleNavigation, 100);
+    return () => clearTimeout(timer);
+  }
+}, [location.pathname, isMobile, setIsCollapsed]);
+```
+
+To:
+```jsx
+useEffect(() => {
+  // Only close the mobile sheet when actually navigating to a different page
+  if (isMobileSheet && typeof setIsCollapsed === 'function') {
+    // setIsCollapsed in mobile context is actually the close handler
+    setIsCollapsed();
+  }
+}, [location.pathname]); // Only depend on pathname changes
+```
+
+### 3. Layout component already passes the prop
+The Layout component was already passing `isMobileSheet={true}` to the Sidebar when rendered in mobile context.
+
+## Result
+- Mobile sidebar now stays open when clicked
+- Sidebar only closes when user navigates to a different page
+- No more immediate closing issue
+
+## Testing
+1. Open the app on mobile or resize browser to < 768px width
+2. Click the menu button to open sidebar
+3. Sidebar should remain open
+4. Click any navigation link
+5. Sidebar should close after navigation
+
+## Files Modified
+- `/workspace/src/components/layout/Sidebar.jsx`

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -546,7 +546,7 @@ function NavItem({ item, level = 0, isCollapsed }) {
 }
 
 // Main Sidebar Component
-export const Sidebar = ({ isCollapsed, setIsCollapsed }) => {
+export const Sidebar = ({ isCollapsed, setIsCollapsed, isMobileSheet = false }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const { t, i18n } = useTranslation();
   const { theme, setTheme } = useTheme();
@@ -586,19 +586,12 @@ export const Sidebar = ({ isCollapsed, setIsCollapsed }) => {
 
   // Close mobile sidebar on navigation
   useEffect(() => {
-    if (isMobile && typeof setIsCollapsed === 'function') {
-      // This will close the mobile sheet when navigating
-      const handleNavigation = () => {
-        if (window.innerWidth < 768) {
-          setIsCollapsed(true);
-        }
-      };
-      
-      // Add slight delay to allow navigation to complete
-      const timer = setTimeout(handleNavigation, 100);
-      return () => clearTimeout(timer);
+    // Only close the mobile sheet when actually navigating to a different page
+    if (isMobileSheet && typeof setIsCollapsed === 'function') {
+      // setIsCollapsed in mobile context is actually the close handler
+      setIsCollapsed();
     }
-  }, [location.pathname, isMobile, setIsCollapsed]);
+  }, [location.pathname]); // Only depend on pathname changes, not on isMobileSheet or setIsCollapsed
 
   // Filter navigation items based on search
   const filterNavItems = (items, query) => {


### PR DESCRIPTION
Fix mobile sidebar immediately closing by refining the navigation close logic.

The `useEffect` responsible for closing the sidebar on navigation was incorrectly triggering on every render when `isMobile` was true, causing the sidebar to close immediately upon opening. This PR modifies the effect to only close the sidebar when `isMobileSheet` is true and `location.pathname` changes, ensuring it only closes on actual navigation.

---

[Open in Web](https://cursor.com/agents?id=bc-bd3826cc-95d7-4319-9346-f1993fe86b7d) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-bd3826cc-95d7-4319-9346-f1993fe86b7d) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)