### PR TITLE
Add dialog title for mobile accessibility

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -2,7 +2,8 @@ import { useState, useEffect } from 'react';
 import { Sidebar } from './Sidebar';
 import { Header } from './Header';
 import { cn } from '@/lib/utils';
-import { Sheet, SheetContent } from '@/components/ui/sheet';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet';
+import { VisuallyHidden } from '@/components/ui/visually-hidden';
 import { useMediaQuery } from '@/hooks/use-media-query';
 import { useTranslation } from 'react-i18next';
 import { useLocation } from 'react-router-dom';
@@ -55,6 +56,12 @@ export function Layout({ children }) {
             side="left" 
             className="p-0 w-80 max-w-[85vw] border-0 overflow-y-auto"
           >
+            <VisuallyHidden>
+              <SheetHeader>
+                <SheetTitle>Navigation Menu</SheetTitle>
+                <SheetDescription>Navigate through the application</SheetDescription>
+              </SheetHeader>
+            </VisuallyHidden>
             <Sidebar 
               isCollapsed={false} 
               setIsCollapsed={handleMobileSidebarClose}

--- a/src/components/ui/sidebar.jsx
+++ b/src/components/ui/sidebar.jsx
@@ -23,6 +23,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip"
+import { VisuallyHidden } from "@/components/ui/visually-hidden"
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state"
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7
@@ -167,10 +168,12 @@ function Sidebar({
             }
           }
           side={side}>
-          <SheetHeader className="sr-only">
-            <SheetTitle>Sidebar</SheetTitle>
-            <SheetDescription>Displays the mobile sidebar.</SheetDescription>
-          </SheetHeader>
+          <VisuallyHidden>
+            <SheetHeader>
+              <SheetTitle>Navigation Menu</SheetTitle>
+              <SheetDescription>Navigate through the application</SheetDescription>
+            </SheetHeader>
+          </VisuallyHidden>
           <div className="flex h-full w-full flex-col">{children}</div>
         </SheetContent>
       </Sheet>

--- a/src/components/ui/visually-hidden.jsx
+++ b/src/components/ui/visually-hidden.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+export function VisuallyHidden({ children, ...props }) {
+  return (
+    <span
+      style={{
+        position: 'absolute',
+        width: '1px',
+        height: '1px',
+        padding: 0,
+        margin: '-1px',
+        overflow: 'hidden',
+        clip: 'rect(0, 0, 0, 0)',
+        whiteSpace: 'nowrap',
+        borderWidth: 0,
+      }}
+      {...props}
+    >
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `DialogTitle` and `DialogDescription` to `SheetContent` components to resolve accessibility warnings.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `SheetContent` (which internally uses Radix UI's `DialogContent`) was generating console warnings because it lacked a properly structured `DialogTitle` and `DialogDescription` for screen readers. Although a `sr-only` header was present, it wasn't sufficient for Radix UI's accessibility checks. This PR introduces the required `SheetTitle` and `SheetDescription` wrapped in a new `VisuallyHidden` component to satisfy these accessibility requirements without altering the visual layout.

---

[Open in Web](https://cursor.com/agents?id=bc-1cc01568-24de-482f-9afe-de66029e355a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-1cc01568-24de-482f-9afe-de66029e355a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)