### PR TITLE
Monitor and resolve javascript errors

### DIFF
--- a/SUPABASE_INITIALIZATION_FIX.md
+++ b/SUPABASE_INITIALIZATION_FIX.md
@@ -1,0 +1,26 @@
+# Supabase Initialization Error Fix
+
+## Issue
+The application was throwing an error: `Uncaught ReferenceError: Cannot access 'ze' before initialization` in the minified Supabase module (`supabase-DifbsjIN.js`).
+
+## Root Cause
+The error was caused by a temporal dead zone issue in `/src/lib/supabase.js`. The `customFetch` function was being referenced in the Supabase client configuration before it was defined in the code.
+
+## Solution
+Moved the function definitions (`getAuthToken` and `customFetch`) before their usage in the Supabase client initialization. This ensures that the functions are available when the client is created.
+
+### Changes Made:
+1. Moved `getAuthToken` function definition from line 65 to line 40
+2. Moved `customFetch` function definition from line 71 to line 46
+3. These functions are now defined before being used in the `createClient` calls
+
+## Result
+- The build now completes successfully
+- The initialization error has been resolved
+- The Supabase client can now properly initialize with the custom fetch configuration
+
+## Prevention
+To prevent similar issues in the future:
+- Always define functions before using them, especially in module initialization code
+- Be aware that const/let declarations are not hoisted like function declarations
+- Test builds regularly to catch initialization errors early

--- a/dist/index.html
+++ b/dist/index.html
@@ -11,12 +11,12 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@300;400;500;600;700&family=Tajawal:wght@300;400;500;700&family=Cairo:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Ethereum conflict resolver - must be loaded first -->
     <script src="/ethereum-conflict-resolver.js"></script>
-    <script type="module" crossorigin src="/assets/index-MerdXrbv.js"></script>
-    <link rel="modulepreload" crossorigin href="/assets/lucide-DwqDjEcC.js">
-    <link rel="modulepreload" crossorigin href="/assets/tiny-invariant-B78de1dJ.js">
+    <script type="module" crossorigin src="/assets/index-C-TrnEYx.js"></script>
+    <link rel="modulepreload" crossorigin href="/assets/lucide-BQWpxqeR.js">
+    <link rel="modulepreload" crossorigin href="/assets/tiny-invariant-3zKhYqWb.js">
     <link rel="modulepreload" crossorigin href="/assets/preload-helper-BlTxHScW.js">
-    <link rel="modulepreload" crossorigin href="/assets/formatters-CaywRV5d.js">
-    <link rel="modulepreload" crossorigin href="/assets/supabase-DYxLv9JR.js">
+    <link rel="modulepreload" crossorigin href="/assets/formatters-5ejm5pL2.js">
+    <link rel="modulepreload" crossorigin href="/assets/supabase-DMVnuCkg.js">
     <link rel="stylesheet" crossorigin href="/assets/index-blysx9u7.css">
   </head>
   <body dir="ltr">

--- a/node_modules/.pnpm-workspace-state.json
+++ b/node_modules/.pnpm-workspace-state.json
@@ -1,5 +1,5 @@
 {
-  "lastValidatedTimestamp": 1753700409838,
+  "lastValidatedTimestamp": 1753703253742,
   "projects": {},
   "pnpmfileExists": false,
   "settings": {

--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -38,6 +38,23 @@ const createMockClient = () => {
   };
 };
 
+// Function to get current auth token
+const getAuthToken = () => {
+  const session = JSON.parse(localStorage.getItem('osol-auth') || '{}');
+  return session?.access_token || supabaseAnonKey;
+};
+
+// Custom fetch function to ensure proper headers
+const customFetch = (url, options = {}) => {
+  const token = getAuthToken();
+  const headers = {
+    ...options.headers,
+    'apikey': supabaseAnonKey,
+    'Authorization': `Bearer ${token}`
+  };
+  return fetch(url, { ...options, headers });
+};
+
 // Create main Supabase client or mock if not configured
 export const supabase = isSupabaseConfigured 
   ? createClient(supabaseUrl, supabaseAnonKey, {
@@ -61,23 +78,6 @@ export const supabase = isSupabaseConfigured
       }
     })
   : createMockClient();
-
-// Function to get current auth token
-const getAuthToken = () => {
-  const session = JSON.parse(localStorage.getItem('osol-auth') || '{}');
-  return session?.access_token || supabaseAnonKey;
-};
-
-// Custom fetch function to ensure proper headers
-const customFetch = (url, options = {}) => {
-  const token = getAuthToken();
-  const headers = {
-    ...options.headers,
-    'apikey': supabaseAnonKey,
-    'Authorization': `Bearer ${token}`
-  };
-  return fetch(url, { ...options, headers });
-};
 
 // Create a client specifically for kastle_banking schema
 export const supabaseBanking = isSupabaseConfigured


### PR DESCRIPTION
Fix 'Cannot access before initialization' error by reordering function definitions in Supabase client setup.

The `customFetch` and `getAuthToken` functions were being referenced in `createClient` calls before their definitions, leading to a temporal dead zone error in the bundled JavaScript. Moving these definitions to precede their usage resolves this initialization issue.

---

[Open in Web](https://cursor.com/agents?id=bc-e6bc43ef-5e17-4c6a-b537-9eefff5d0b9a) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e6bc43ef-5e17-4c6a-b537-9eefff5d0b9a) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)