### PR TITLE
Fix mobile sidebar immediate close

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -49,27 +49,29 @@ export function Layout({ children }) {
         </div>
       )}
       
-      {/* Mobile Sidebar */}
-      {isMobile && (
-        <Sheet open={isMobileSidebarOpen} onOpenChange={setIsMobileSidebarOpen}>
-          <SheetContent 
-            side="left" 
-            className="p-0 w-80 max-w-[85vw] border-0 overflow-y-auto"
-          >
-            <VisuallyHidden>
-              <SheetHeader>
-                <SheetTitle>Navigation Menu</SheetTitle>
-                <SheetDescription>Navigate through the application</SheetDescription>
-              </SheetHeader>
-            </VisuallyHidden>
-            <Sidebar 
-              isCollapsed={false} 
-              setIsCollapsed={handleMobileSidebarClose}
-              isMobileSheet={true}
-            />
-          </SheetContent>
-        </Sheet>
-      )}
+      {/* Mobile Sidebar - Always render Sheet to prevent remounting */}
+      <Sheet open={isMobile && isMobileSidebarOpen} onOpenChange={(open) => {
+        if (isMobile) {
+          setIsMobileSidebarOpen(open);
+        }
+      }}>
+        <SheetContent 
+          side="left" 
+          className="p-0 w-80 max-w-[85vw] border-0 overflow-y-auto"
+        >
+          <VisuallyHidden>
+            <SheetHeader>
+              <SheetTitle>Navigation Menu</SheetTitle>
+              <SheetDescription>Navigate through the application</SheetDescription>
+            </SheetHeader>
+          </VisuallyHidden>
+          <Sidebar 
+            isCollapsed={false} 
+            setIsCollapsed={handleMobileSidebarClose}
+            isMobileSheet={true}
+          />
+        </SheetContent>
+      </Sheet>
       
       <div className={cn(
         "flex-1 flex flex-col min-w-0"

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { changeLanguage } from '@/i18n/i18n';
@@ -394,7 +394,7 @@ const Clock = ({ className }) => (
 );
 
 // Navigation item component
-function NavItem({ item, level = 0, isCollapsed }) {
+function NavItem({ item, level = 0, isCollapsed, onNavigate }) {
   const location = useLocation();
   const { t, i18n } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
@@ -472,7 +472,7 @@ function NavItem({ item, level = 0, isCollapsed }) {
         {!isCollapsed && (
           <CollapsibleContent className="mt-1">
             {item.items.map((child, index) => (
-              <NavItem key={index} item={child} level={level + 1} isCollapsed={isCollapsed} />
+              <NavItem key={index} item={child} level={level + 1} isCollapsed={isCollapsed} onNavigate={onNavigate} />
             ))}
           </CollapsibleContent>
         )}
@@ -490,7 +490,7 @@ function NavItem({ item, level = 0, isCollapsed }) {
       )}
       asChild
     >
-      <Link to={item.href}>
+      <Link to={item.href} onClick={onNavigate}>
         {ItemIcon && (
           <div className={cn(
             "p-2 rounded-lg transition-colors",
@@ -584,14 +584,7 @@ export const Sidebar = ({ isCollapsed, setIsCollapsed, isMobileSheet = false }) 
     return () => window.removeEventListener('resize', checkMobile);
   }, []);
 
-  // Close mobile sidebar on navigation
-  useEffect(() => {
-    // Only close the mobile sheet when actually navigating to a different page
-    if (isMobileSheet && typeof setIsCollapsed === 'function') {
-      // setIsCollapsed in mobile context is actually the close handler
-      setIsCollapsed();
-    }
-  }, [location.pathname]); // Only depend on pathname changes, not on isMobileSheet or setIsCollapsed
+  // We'll handle closing on navigation through click handlers instead
 
   // Filter navigation items based on search
   const filterNavItems = (items, query) => {
@@ -733,7 +726,17 @@ export const Sidebar = ({ isCollapsed, setIsCollapsed, isMobileSheet = false }) 
               )}
               <div className="space-y-1">
                 {section.items.map((item, index) => (
-                  <NavItem key={index} item={item} isCollapsed={isCollapsed} />
+                  <NavItem 
+                    key={index} 
+                    item={item} 
+                    isCollapsed={isCollapsed}
+                    onNavigate={() => {
+                      // Close mobile sidebar on navigation
+                      if (isMobileSheet && typeof setIsCollapsed === 'function') {
+                        setIsCollapsed();
+                      }
+                    }}
+                  />
                 ))}
               </div>
             </div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix mobile sidebar immediately closing by changing its close trigger from location change to navigation link click.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous `useEffect` in `Sidebar.jsx` was closing the mobile sidebar on *any* location change, including initial renders or re-renders, making it impossible to keep open. This PR removes that `useEffect` and instead closes the sidebar only when a navigation link inside it is explicitly clicked. The `Sheet` component in `Layout.jsx` is also now always rendered to prevent unmounting/remounting issues that could interfere with its state.

---

[Open in Web](https://cursor.com/agents?id=bc-e3597dfa-1f85-4518-a14c-4b30402efca3) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-e3597dfa-1f85-4518-a14c-4b30402efca3) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)