### PR TITLE
Fix mobile sidebar search reset

### DIFF
--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -66,10 +66,11 @@ export function Layout({ children }) {
             </SheetHeader>
           </VisuallyHidden>
           <div className="h-full overflow-hidden bg-white dark:bg-gray-950">
-            <Sidebar 
-              isCollapsed={false} 
+            <Sidebar
+              isCollapsed={false}
               setIsCollapsed={handleMobileSidebarClose}
               isMobileSheet={true}
+              mobileOpen={isMobileSidebarOpen}
             />
           </div>
         </SheetContent>

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -546,7 +546,7 @@ function NavItem({ item, level = 0, isCollapsed, onNavigate }) {
 }
 
 // Main Sidebar Component
-export const Sidebar = ({ isCollapsed, setIsCollapsed, isMobileSheet = false }) => {
+export const Sidebar = ({ isCollapsed, setIsCollapsed, isMobileSheet = false, mobileOpen = false }) => {
   const [searchQuery, setSearchQuery] = useState('');
   const { t, i18n } = useTranslation();
   const { theme, setTheme } = useTheme();
@@ -591,15 +591,14 @@ export const Sidebar = ({ isCollapsed, setIsCollapsed, isMobileSheet = false }) 
     return () => window.removeEventListener('resize', checkMobile);
   }, []);
 
-  // Force navigation items to be visible on mobile sheet
+  // Reset search and ensure nav items when mobile sheet opens
   useEffect(() => {
-    if (isMobileSheet) {
-      setSearchQuery(''); // Clear search when opening mobile sheet
-      // Re-initialize navigation items for mobile
+    if (isMobileSheet && mobileOpen) {
+      setSearchQuery('');
       const items = getNavigationItems(t, hasTranslations);
       setNavigationItems(items);
     }
-  }, [isMobileSheet, t, hasTranslations]);
+  }, [mobileOpen, isMobileSheet, t, hasTranslations]);
 
   // Filter navigation items based on search
   const filterNavItems = (items, query) => {


### PR DESCRIPTION
## Summary
- ensure Sidebar resets search when the mobile sheet opens by tracking open state
- pass `mobileOpen` prop from Layout so Sidebar knows when the sheet is opened

## Testing
- `npm run lint` *(fails: 272 problems)*

------
https://chatgpt.com/codex/tasks/task_e_6887928f392483299c19e55a3d26462e