### PR TITLE
Fix build errors in sidebar component

### DIFF
--- a/src/components/layout/MobileSidebar.jsx
+++ b/src/components/layout/MobileSidebar.jsx
@@ -97,16 +97,6 @@ const navigationData = [
   }
 ];
 
-// Clock component
-function Clock({ className }) {
-  return (
-    <svg className={className} fill="none" height="16" stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" viewBox="0 0 24 24" width="16">
-      <circle cx="12" cy="12" r="10" />
-      <polyline points="12 6 12 12 16 14" />
-    </svg>
-  );
-}
-
 // Simple navigation item
 function NavItem({ item, onClick }) {
   const location = useLocation();

--- a/src/components/layout/NewSidebar.jsx
+++ b/src/components/layout/NewSidebar.jsx
@@ -350,26 +350,6 @@ const getNavigationConfig = (t) => [
   }
 ];
 
-// Clock component
-function Clock({ className }) {
-  return (
-    <svg
-      className={className}
-      fill="none"
-      height="16"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="2"
-      viewBox="0 0 24 24"
-      width="16"
-    >
-      <circle cx="12" cy="12" r="10" />
-      <polyline points="12 6 12 12 16 14" />
-    </svg>
-  );
-}
-
 // Navigation Item Component
 function NavigationItem({ item, isCollapsed, onItemClick, level = 0 }) {
   const location = useLocation();

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,9 @@
 /* src/index.css */
+@import './styles/new-sidebar.css';
+@import './styles/mobile-sidebar.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* Import new sidebar styles */
-@import './styles/new-sidebar.css';
-@import './styles/mobile-sidebar.css';
 
 @layer base {
   :root {


### PR DESCRIPTION
Fixes build errors by removing duplicate `Clock` component definitions and reordering CSS `@import` rules.

The build was failing due to a "Clock has already been declared" error because the `Clock` component was defined in both `NewSidebar.jsx` and `MobileSidebar.jsx`. Additionally, PostCSS was throwing an error because `@import` rules were not at the very top of `src/index.css`.

---

[Open in Web](https://cursor.com/agents?id=bc-894145f9-d2ba-4108-9a45-e669c1ae0e9e) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-894145f9-d2ba-4108-9a45-e669c1ae0e9e) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)