### PR TITLE
Remove green sidebar and rename OSOL Collection

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -825,7 +825,7 @@
     }
   },
   "sidebar": {
-    "title": "OSOL Collection",
+    "title": "KONAN Pro",
     "home": "Home",
     "executive": "Executive",
     "executiveDashboard": "Executive Dashboard",

--- a/src/components/layout/ModernLayout.jsx
+++ b/src/components/layout/ModernLayout.jsx
@@ -91,16 +91,6 @@ const LayoutContent = () => {
         {/* Page content */}
         <main className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-50 dark:bg-gray-900">
           <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-            {/* Development indicator - remove in production */}
-            <div className="mb-4 p-4 bg-gradient-to-r from-green-500 to-blue-500 text-white rounded-lg shadow-lg">
-              <div className="flex items-center gap-2">
-                <span className="text-2xl">🚀</span>
-                <div>
-                  <h3 className="text-lg font-bold">Modern Sidebar Active</h3>
-                  <p className="text-sm opacity-90">You are using the NEW organized sidebar with RTL support</p>
-                </div>
-              </div>
-            </div>
             <ErrorBoundaryWrapper>
               <React.Suspense fallback={
                 <div className="flex items-center justify-center h-64">

--- a/src/components/layout/ModernSidebar.jsx
+++ b/src/components/layout/ModernSidebar.jsx
@@ -316,7 +316,7 @@ const ModernSidebar = () => {
             </div>
             <div className={`flex flex-col ${isRTL && 'text-right'}`}>
               <span className="text-xl font-bold bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">
-                OSOL Collection
+                KONAN Pro
               </span>
               <span className="text-xs text-muted-foreground flex items-center gap-1">
                 <Zap className="h-3 w-3" />


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove 'Modern Sidebar Active' development banner and update branding from 'OSOL Collection' to 'KONAN Pro'.

---
<a href="https://cursor.com/background-agent?bcId=bc-72e6489a-5c75-4f1c-8420-d6c536891289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72e6489a-5c75-4f1c-8420-d6c536891289">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>