### PR TITLE
Fix report generation and api errors

### DIFF
--- a/REPORTS_PAGE_FIXES.md
+++ b/REPORTS_PAGE_FIXES.md
@@ -1,0 +1,55 @@
+# Reports Page Error Fixes
+
+## Issues Fixed
+
+### 1. SQL Query Error - "column transactions.transaction_amountasamount does not exist"
+
+**Issue**: The Supabase query was incorrectly formatting the column alias, causing `transaction_amount as amount` to be concatenated as `transaction_amountasamount`.
+
+**Fix**: Removed the column alias from the select statement in `/workspace/src/services/comprehensiveReportService.js`:
+```javascript
+// Before:
+.select('transaction_amount as amount, transaction_type_id, transaction_date')
+
+// After:
+.select('transaction_amount, transaction_type_id, transaction_date')
+```
+
+Also updated the code that references the field:
+```javascript
+// Before:
+const totalRevenue = revenueData?.reduce((sum, t) => sum + (t.amount || 0), 0) || 0;
+
+// After:
+const totalRevenue = revenueData?.reduce((sum, t) => sum + (t.transaction_amount || 0), 0) || 0;
+```
+
+### 2. PDF Generation Error - "t.autoTable is not a function"
+
+**Issue**: The `jspdf-autotable` library was not being imported correctly, causing the `autoTable` function to be undefined.
+
+**Fix**: Updated the import and usage in `/workspace/src/utils/reportGenerator.js`:
+```javascript
+// Before:
+import jsPDF from 'jspdf';
+import 'jspdf-autotable';
+// Usage: pdf.autoTable({...})
+
+// After:
+import { jsPDF } from 'jspdf';
+import { autoTable } from 'jspdf-autotable';
+// Usage: autoTable(pdf, {...})
+```
+
+All occurrences of `pdf.autoTable(` were replaced with `autoTable(pdf, ` throughout the file.
+
+## Testing
+
+After applying these fixes:
+1. The SQL query error should be resolved and data should load correctly
+2. PDF generation should work without errors
+3. The reports page should function properly
+
+## Note
+
+The repeated "Port disconnected, reconnecting..." messages in the console appear to be related to browser extensions (likely wallet extensions like Phantom, Keplr, etc.) and are not related to the application code.

--- a/src/services/comprehensiveReportService.js
+++ b/src/services/comprehensiveReportService.js
@@ -37,7 +37,7 @@ class ComprehensiveReportService {
       // Get transaction data for revenue
       const { data: revenueData, error: revenueError } = await supabaseBanking
         .from(TABLES.TRANSACTIONS)
-        .select('transaction_amount as amount, transaction_type_id, transaction_date')
+        .select('transaction_amount, transaction_type_id, transaction_date')
         .gte('transaction_date', startDate)
         .lte('transaction_date', endDate)
         .in('transaction_type_id', [1, 2, 3]); // Credit transactions
@@ -53,7 +53,7 @@ class ComprehensiveReportService {
       if (loanError) throw loanError;
 
       // Calculate totals
-      const totalRevenue = revenueData?.reduce((sum, t) => sum + (t.amount || 0), 0) || 0;
+      const totalRevenue = revenueData?.reduce((sum, t) => sum + (t.transaction_amount || 0), 0) || 0;
       const interestIncome = loanData?.reduce((sum, loan) => {
         return sum + ((loan.outstanding_balance * loan.interest_rate / 100 / 12) || 0);
       }, 0) || 0;

--- a/src/utils/reportGenerator.js
+++ b/src/utils/reportGenerator.js
@@ -1,5 +1,5 @@
-import jsPDF from 'jspdf';
-import 'jspdf-autotable';
+import { jsPDF } from 'jspdf';
+import { autoTable } from 'jspdf-autotable';
 import * as XLSX from 'xlsx';
 import { format } from 'date-fns';
 
@@ -110,7 +110,7 @@ class ReportGenerator {
       ['Total Revenue', this.formatCurrency(data.revenue.totalRevenue)]
     ];
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: y,
       head: [['Item', 'Amount (SAR)']],
       body: revenueData,
@@ -136,7 +136,7 @@ class ReportGenerator {
       ['Total Expenses', this.formatCurrency(data.expenses.totalExpenses)]
     ];
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: y,
       head: [['Item', 'Amount (SAR)']],
       body: expensesData,
@@ -185,7 +185,7 @@ class ReportGenerator {
       ['Total Assets', this.formatCurrency(data.assets.totalAssets)]
     ];
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: y,
       head: [['Item', 'Amount (SAR)']],
       body: assetsData,
@@ -210,7 +210,7 @@ class ReportGenerator {
       ['Total Liabilities', this.formatCurrency(data.liabilities.totalLiabilities)]
     ];
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: y,
       head: [['Item', 'Amount (SAR)']],
       body: liabilitiesData,
@@ -235,7 +235,7 @@ class ReportGenerator {
       ['Total Equity', this.formatCurrency(data.equity.totalEquity)]
     ];
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: y,
       head: [['Item', 'Amount (SAR)']],
       body: equityData,
@@ -282,7 +282,7 @@ class ReportGenerator {
       ['Closing Cash Balance', '', this.formatCurrency(data.closingBalance)]
     ];
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: y,
       head: [['Item', 'Amount (SAR)', 'Total (SAR)']],
       body: cashFlowData,
@@ -320,7 +320,7 @@ class ReportGenerator {
       ['Capital Adequacy Ratio', `${data.capitalAdequacyRatio}%`]
     ];
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: y,
       head: [['Metric', 'Value']],
       body: metricsData,
@@ -345,7 +345,7 @@ class ReportGenerator {
       ['Critical Risk', data.riskDistribution.critical]
     ];
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: y,
       head: [['Risk Category', 'Number of Accounts']],
       body: riskData,
@@ -400,7 +400,7 @@ class ReportGenerator {
 
     const segmentData = Object.entries(data.acquisitionBySegment).map(([segment, count]) => [segment, count]);
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: y,
       head: [['Segment', 'New Customers']],
       body: segmentData,


### PR DESCRIPTION
Fixes report page errors by correcting Supabase column aliasing and updating jspdf-autotable import and usage.

The Supabase query for reports failed because `transaction_amount as amount` was misinterpreted as `transaction_amountasamount`. This was resolved by removing the alias from the select statement and directly using `transaction_amount`. Additionally, PDF generation failed due to incorrect `jspdf-autotable` import and usage, which was fixed by switching to named exports and passing the pdf instance explicitly to `autoTable`.

---
<a href="https://cursor.com/background-agent?bcId=bc-38297638-6226-403f-b664-2ca36987d319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-38297638-6226-403f-b664-2ca36987d319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>