### PR TITLE
Fetch and process dashboard data

### DIFF
--- a/src/services/dashboardDetailsService.js
+++ b/src/services/dashboardDetailsService.js
@@ -1880,7 +1880,7 @@ export const chartDetailsService = {
         break;
       case 'monthly':
         if (subType === 'revenue') {
-          return this.getMonthlyRevenueDetails();
+          return revenueDetailsService.getMonthlyRevenueDetails();
         }
         break;
       case 'customer':


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix 'this.getMonthlyRevenueDetails is not a function' error by calling the method from the correct service.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `getMonthlyRevenueDetails` method was incorrectly called using `this` within `chartDetailsService`, but it is defined in `revenueDetailsService`. This PR corrects the call to use `revenueDetailsService.getMonthlyRevenueDetails()`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b2ec3d3-6223-4d11-a3a7-d2be85bf2d3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b2ec3d3-6223-4d11-a3a7-d2be85bf2d3c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>