### PR TITLE
Fix balance sheet generation and schema issues

### DIFF
--- a/fix_loan_relationship.sql
+++ b/fix_loan_relationship.sql
@@ -1,0 +1,1 @@
+ALTER TABLE kastle_banking.loan_accounts ADD CONSTRAINT fk_loan_accounts_loan_type FOREIGN KEY (loan_type_id) REFERENCES kastle_banking.loan_types(type_id);


### PR DESCRIPTION
Add foreign key constraint between `loan_accounts` and `loan_types` tables.

This fixes the "Could not find a relationship" error during balance sheet report generation, as Supabase's PostgREST API requires this explicit foreign key for the `!inner` join syntax.

---
<a href="https://cursor.com/background-agent?bcId=bc-229d90f0-38c7-49a6-b345-261be28d92d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-229d90f0-38c7-49a6-b345-261be28d92d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>