### PR TITLE
Fix undefined widget data cache

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -11,11 +11,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+Arabic:wght@300;400;500;600;700&family=Tajawal:wght@300;400;500;700&family=Cairo:wght@300;400;600;700&display=swap" rel="stylesheet">
     <!-- Ethereum conflict resolver - must be loaded first -->
     <script src="/ethereum-conflict-resolver.js"></script>
-    <script type="module" crossorigin src="/assets/index-DNNjg2yx.js"></script>
+    <script type="module" crossorigin src="/assets/index-SfYjQekO.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/lucide-D54ktLR8.js">
     <link rel="modulepreload" crossorigin href="/assets/tiny-invariant-BKYL3iPD.js">
     <link rel="modulepreload" crossorigin href="/assets/formatters-CQOS6jkS.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-Cp2OTs8N.css">
+    <link rel="stylesheet" crossorigin href="/assets/index--mlblMIa.css">
   </head>
   <body dir="ltr">
     <div id="root"></div>


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix `ReferenceError: widgetDataCache is not defined` by correcting widget data access and state variable usage.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `renderWidget` function was attempting to use `widgetDataCache`, `loadingWidgets`, and `errorWidgets` which were not properly defined or mapped to existing state variables. This PR re-maps these to the correct `widgetData` and `widgetLoadingStates` variables, uses the correct composite key (`${widget.section}_${widget.widget}`) for data lookup, and renames a shadowed local variable to `widgetDataForWidget` to ensure proper data flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7eec993-865f-4a9f-bddb-0583a0dfdff9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7eec993-865f-4a9f-bddb-0583a0dfdff9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>