### PR TITLE
Build project with recharts error

### DIFF
--- a/src/pages/ExecutiveDashboard.jsx
+++ b/src/pages/ExecutiveDashboard.jsx
@@ -38,8 +38,7 @@ import {
   PolarRadiusAxis,
   Radar,
   ComposedChart,
-  Scatter,
-  MoreVertical
+  Scatter
 } from 'recharts';
 import { 
   TrendingUp, 
@@ -76,7 +75,8 @@ import {
   Globe,
   Building2,
   Briefcase,
-  TrendingUpIcon
+  TrendingUpIcon,
+  MoreVertical
 } from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Separator } from '@/components/ui/separator';


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Move `MoreVertical` import from `recharts` to `lucide-react` to fix the build error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The build was failing because `MoreVertical` is an icon component from `lucide-react`, but it was incorrectly imported from the `recharts` library, which does not export it.

---
<a href="https://cursor.com/background-agent?bcId=bc-6825f902-e940-41ae-b855-0d82916977c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6825f902-e940-41ae-b855-0d82916977c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>