### PR TITLE
Fix pdf report generation error

### DIFF
--- a/src/utils/reportGenerator.js
+++ b/src/utils/reportGenerator.js
@@ -121,7 +121,7 @@ class ReportGenerator {
       margin: { left: 20, right: 20 }
     });
     
-    currentY = doc.previousAutoTable.finalY + 10;
+    currentY = doc.lastAutoTable.finalY + 10;
     
     // Expenses Section
     doc.setFontSize(14);
@@ -151,7 +151,7 @@ class ReportGenerator {
       margin: { left: 20, right: 20 }
     });
     
-    currentY = doc.previousAutoTable.finalY + 10;
+    currentY = doc.lastAutoTable.finalY + 10;
     
     // Summary Section
     doc.setFontSize(14);
@@ -178,7 +178,7 @@ class ReportGenerator {
     
     // Add metrics if available
     if (data.metrics) {
-      currentY = doc.previousAutoTable.finalY + 15;
+      currentY = doc.lastAutoTable.finalY + 15;
       doc.setFontSize(14);
       doc.setFont(undefined, 'bold');
       doc.text('Key Metrics', 20, currentY);
@@ -242,7 +242,7 @@ class ReportGenerator {
       margin: { left: 20, right: 20 }
     });
     
-    currentY = doc.previousAutoTable.finalY + 10;
+    currentY = doc.lastAutoTable.finalY + 10;
     
     // Liabilities Section
     doc.setFontSize(14);
@@ -267,7 +267,7 @@ class ReportGenerator {
       margin: { left: 20, right: 20 }
     });
     
-    currentY = doc.previousAutoTable.finalY + 10;
+    currentY = doc.lastAutoTable.finalY + 10;
     
     // Equity Section
     doc.setFontSize(14);
@@ -328,7 +328,7 @@ class ReportGenerator {
         margin: { left: 20, right: 20 }
       });
       
-      currentY = doc.previousAutoTable.finalY + 10;
+      currentY = doc.lastAutoTable.finalY + 10;
     }
 
     // Breakdown by Segment
@@ -353,7 +353,7 @@ class ReportGenerator {
         margin: { left: 20, right: 20 }
       });
       
-      currentY = doc.previousAutoTable.finalY + 10;
+      currentY = doc.lastAutoTable.finalY + 10;
     }
 
     // Recent Customers
@@ -417,7 +417,7 @@ class ReportGenerator {
         margin: { left: 20, right: 20 }
       });
       
-      currentY = doc.previousAutoTable.finalY + 10;
+      currentY = doc.lastAutoTable.finalY + 10;
     }
 
     // Risk by Category


### PR DESCRIPTION
Update jsPDF AutoTable property from `previousAutoTable` to `lastAutoTable` to resolve PDF generation errors.

The `previousAutoTable` property is deprecated in jsPDF AutoTable versions 3.6.0 and later, leading to a `TypeError: n.previousAutoTable is undefined` when generating reports. This PR updates all instances to use `lastAutoTable`, which is the correct property for the jsPDF AutoTable version (`^5.0.2`) used in the project.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9dd7f66-0706-445b-afb0-c53fcd6cecd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9dd7f66-0706-445b-afb0-c53fcd6cecd7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>