### PR TITLE
Handle Supabase query errors

### DIFF
--- a/test_collection_fixes.js
+++ b/test_collection_fixes.js
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+
+import { CollectionService } from './src/services/collectionService.js';
+
+console.log('Testing Collection Service Fixes...\n');
+
+async function testCollectionCases() {
+  console.log('🔍 Testing Collection Cases Query...');
+  try {
+    const result = await CollectionService.getCollectionCases({
+      page: 1,
+      limit: 5
+    });
+    
+    if (result.success) {
+      console.log('✅ Collection Cases Query: SUCCESS');
+      console.log(`   Found ${result.data?.length || 0} cases`);
+    } else {
+      console.log('❌ Collection Cases Query: FAILED');
+      console.log('   Error:', result.error?.message);
+      console.log('   Details:', result.error?.details);
+    }
+  } catch (error) {
+    console.log('❌ Collection Cases Query: EXCEPTION');
+    console.log('   Error:', error.message);
+  }
+}
+
+async function testOfficerPerformance() {
+  console.log('\n🔍 Testing Officer Performance Query...');
+  try {
+    const result = await CollectionService.getCollectionPerformance('monthly', {});
+    
+    if (result.success) {
+      console.log('✅ Officer Performance Query: SUCCESS');
+      console.log(`   Found ${result.data?.topOfficers?.length || 0} top officers`);
+    } else {
+      console.log('❌ Officer Performance Query: FAILED');
+      console.log('   Error:', result.error?.message);
+      console.log('   Details:', result.error?.details);
+    }
+  } catch (error) {
+    console.log('❌ Officer Performance Query: EXCEPTION');
+    console.log('   Error:', error.message);
+  }
+}
+
+async function testCollectionOverview() {
+  console.log('\n🔍 Testing Collection Overview Query...');
+  try {
+    const result = await CollectionService.getCollectionOverview({});
+    
+    if (result.success) {
+      console.log('✅ Collection Overview Query: SUCCESS');
+      console.log(`   Total cases: ${result.data?.totalCases || 0}`);
+    } else {
+      console.log('❌ Collection Overview Query: FAILED');
+      console.log('   Error:', result.error?.message);
+      console.log('   Details:', result.error?.details);
+    }
+  } catch (error) {
+    console.log('❌ Collection Overview Query: EXCEPTION');
+    console.log('   Error:', error.message);
+  }
+}
+
+async function runTests() {
+  console.log('Starting Collection Service Tests...\n');
+  
+  await testCollectionCases();
+  await testOfficerPerformance();
+  await testCollectionOverview();
+  
+  console.log('\n📊 Test Results Summary:');
+  console.log('All major collection queries have been tested.');
+  console.log('Check the results above for specific issues.');
+  console.log('\nIf tests are still failing, the database schema may need to be updated.');
+}
+
+// Run tests if this file is executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runTests().catch(console.error);
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix Supabase query errors related to schema name typos and officer performance relationship.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses two distinct database query issues:
1.  **Officer Performance Query (PGRST200 error):** The explicit `!officer_id` join syntax was causing a "relationship not found" error. This is fixed by relying on Supabase's automatic relationship detection and adding a robust fallback mechanism.
2.  **Collection Cases Query (PGRST100 error):** Multiple queries had a typo in the schema name (`kastel_banking` instead of `kastle_banking`), leading to parse errors. All instances of this typo have been corrected.

---
<a href="https://cursor.com/background-agent?bcId=bc-971465ff-012d-4077-99de-c22ddd5747ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-971465ff-012d-4077-99de-c22ddd5747ba">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>