### PR TITLE
Fix missing customers phone column for reports

### DIFF
--- a/CUSTOMER_REPORT_FIX.md
+++ b/CUSTOMER_REPORT_FIX.md
@@ -1,0 +1,51 @@
+# Customer Report Database Error Fix
+
+## Issue
+The report generation was failing with the error: `column customers.phone does not exist`
+
+## Root Cause
+The `customers` table in the `kastle_banking` schema doesn't have `phone` or `email` columns. Instead, customer contact information is stored in a separate `customer_contacts` table with the following structure:
+
+- `contact_type`: Can be 'MOBILE', 'HOME', 'WORK', 'EMAIL', or 'FAX'
+- `contact_value`: The actual contact value (phone number or email address)
+- `is_primary`: Boolean flag indicating if this is the primary contact
+
+## Solution
+Updated the customer report service (`/workspace/src/services/reports/customerReportService.js`) to:
+
+1. **Modified the query** to include a left join with `customer_contacts`:
+   ```javascript
+   customer_contacts!left(
+     contact_type,
+     contact_value,
+     is_primary
+   )
+   ```
+
+2. **Updated the data mapping** to extract phone and email from the contacts array:
+   ```javascript
+   const emailContact = c.customer_contacts?.find(contact => 
+     contact.contact_type === 'EMAIL' && contact.is_primary
+   ) || c.customer_contacts?.find(contact => contact.contact_type === 'EMAIL');
+   
+   const phoneContact = c.customer_contacts?.find(contact => 
+     (contact.contact_type === 'MOBILE' || contact.contact_type === 'WORK' || contact.contact_type === 'HOME') && contact.is_primary
+   ) || c.customer_contacts?.find(contact => 
+     contact.contact_type === 'MOBILE' || contact.contact_type === 'WORK' || contact.contact_type === 'HOME'
+   );
+   ```
+
+3. **Added fallback values** to handle cases where no contact information is found:
+   ```javascript
+   email: emailContact?.contact_value || 'N/A',
+   phone: phoneContact?.contact_value || 'N/A',
+   ```
+
+## Impact
+- The report generation should now work correctly
+- Customer phone and email information will be properly displayed in reports
+- The solution prioritizes primary contacts but falls back to any available contact if no primary is set
+
+## Related Tables
+- `kastle_banking.customers` - Main customer information
+- `kastle_banking.customer_contacts` - Customer contact details (phone, email, etc.)

--- a/src/services/reports/customerReportService.js
+++ b/src/services/reports/customerReportService.js
@@ -7,20 +7,23 @@ class CustomerReportService {
    */
   async getCustomerAcquisition(startDate, endDate) {
     try {
-      // Get new customers
+      // Get new customers with contact information
       const { data: newCustomers, error: customerError } = await supabaseBanking
         .from(TABLES.CUSTOMERS)
         .select(`
           customer_id,
           first_name,
           last_name,
-          email,
-          phone,
           created_at,
           customer_type_id,
           customer_types!inner(type_name),
           kyc_status,
-          risk_rating
+          risk_rating,
+          customer_contacts!left(
+            contact_type,
+            contact_value,
+            is_primary
+          )
         `)
         .gte('created_at', startDate)
         .lte('created_at', endDate)
@@ -100,15 +103,28 @@ class CustomerReportService {
           mobile: Math.round(totalNewCustomers * 0.2),
           referral: Math.round(totalNewCustomers * 0.05)
         },
-        recentCustomers: newCustomers?.slice(0, 10).map(c => ({
-          id: c.customer_id,
-          name: `${c.first_name} ${c.last_name}`,
-          email: c.email,
-          phone: c.phone,
-          type: c.customer_types?.type_name,
-          createdAt: c.created_at,
-          kycStatus: c.kyc_status
-        })) || []
+        recentCustomers: newCustomers?.slice(0, 10).map(c => {
+          // Extract email and phone from customer_contacts
+          const emailContact = c.customer_contacts?.find(contact => 
+            contact.contact_type === 'EMAIL' && contact.is_primary
+          ) || c.customer_contacts?.find(contact => contact.contact_type === 'EMAIL');
+          
+          const phoneContact = c.customer_contacts?.find(contact => 
+            (contact.contact_type === 'MOBILE' || contact.contact_type === 'WORK' || contact.contact_type === 'HOME') && contact.is_primary
+          ) || c.customer_contacts?.find(contact => 
+            contact.contact_type === 'MOBILE' || contact.contact_type === 'WORK' || contact.contact_type === 'HOME'
+          );
+          
+          return {
+            id: c.customer_id,
+            name: `${c.first_name} ${c.last_name}`,
+            email: emailContact?.contact_value || 'N/A',
+            phone: phoneContact?.contact_value || 'N/A',
+            type: c.customer_types?.type_name,
+            createdAt: c.created_at,
+            kycStatus: c.kyc_status
+          };
+        }) || []
       };
     } catch (error) {
       console.error('Error generating customer acquisition report:', error);


### PR DESCRIPTION
Fixes customer report generation by fetching phone and email from the `customer_contacts` table instead of the `customers` table.

---
<a href="https://cursor.com/background-agent?bcId=bc-de58d08f-f928-423c-bf47-e119b6e7899f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de58d08f-f928-423c-bf47-e119b6e7899f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>