### PR TITLE
Fix report generator redeclaration error

### DIFF
--- a/src/utils/reportGenerator.js
+++ b/src/utils/reportGenerator.js
@@ -240,8 +240,8 @@ class ReportGenerator {
     currentY = doc.lastAutoTable.finalY + 20;
 
     // Check if we need a new page
-    const pageHeight = doc.internal.pageSize.height;
-    if (currentY > pageHeight - 80) {
+    const actualPageHeight = doc.internal.pageSize.height;
+    if (currentY > actualPageHeight - 80) {
       doc.addPage();
       currentY = 20;
     }


### PR DESCRIPTION
Rename `pageHeight` to `actualPageHeight` to resolve a duplicate variable declaration build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-183f0128-b7de-49f5-9943-fbec83e9b157">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-183f0128-b7de-49f5-9943-fbec83e9b157">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>