### PR TITLE
Fix missing customers segment id column

### DIFF
--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -393,15 +393,7 @@ export const WIDGET_CATALOG = {
           
           // Apply customer segment filter
           if (filters?.customerSegment && filters.customerSegment !== 'all') {
-            const segmentMap = {
-              'vip': 'VIP',
-              'premium': 'Premium',
-              'standard': 'Standard'
-            };
-            const segment = segmentMap[filters.customerSegment];
-            if (segment) {
-              query = query.eq('segment', segment);
-            }
+            query = query.eq('segment', filters.customerSegment);
           }
           
           const { count, error } = await query;
@@ -2709,11 +2701,11 @@ export default function EnhancedDashboard() {
                     </SelectTrigger>
                     <SelectContent>
                       <SelectItem value="all">All Segments</SelectItem>
-                      {filterOptions.customerSegments.map((segment) => (
-                        <SelectItem key={segment.segment_id} value={segment.segment_id}>
-                          {segment.segment_name}
-                        </SelectItem>
-                      ))}
+                      <SelectItem value="RETAIL">Retail</SelectItem>
+                      <SelectItem value="PREMIUM">Premium</SelectItem>
+                      <SelectItem value="HNI">HNI</SelectItem>
+                      <SelectItem value="CORPORATE">Corporate</SelectItem>
+                      <SelectItem value="SME">SME</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/src/services/comprehensiveReportService.js
+++ b/src/services/comprehensiveReportService.js
@@ -13,17 +13,25 @@ class ComprehensiveReportService {
     try {
       const { startDate, endDate } = dateRange;
       
+      // Transform filters to match expected format
+      const transformedFilters = {
+        ...filters,
+        segment: filters.customerSegment || filters.segment || 'all'
+      };
+      // Remove customerSegment to avoid confusion
+      delete transformedFilters.customerSegment;
+      
       switch (reportType) {
         case 'income_statement':
-          return await financialReportService.getIncomeStatement(startDate, endDate, filters);
+          return await financialReportService.getIncomeStatement(startDate, endDate, transformedFilters);
         case 'balance_sheet':
-          return await financialReportService.getBalanceSheet(endDate, filters);
+          return await financialReportService.getBalanceSheet(endDate, transformedFilters);
         case 'cash_flow':
-          return await financialReportService.getCashFlowStatement(startDate, endDate, filters);
+          return await financialReportService.getCashFlowStatement(startDate, endDate, transformedFilters);
         case 'profit_loss':
-          return await financialReportService.getProfitLossStatement(startDate, endDate, filters);
+          return await financialReportService.getProfitLossStatement(startDate, endDate, transformedFilters);
         case 'budget_variance':
-          return await financialReportService.getBudgetVarianceAnalysis(startDate, endDate, filters);
+          return await financialReportService.getBudgetVarianceAnalysis(startDate, endDate, transformedFilters);
         default:
           throw new Error(`Unknown financial report type: ${reportType}`);
       }

--- a/src/services/reports/financialReportService.js
+++ b/src/services/reports/financialReportService.js
@@ -21,7 +21,7 @@ class FinancialReportService {
             customer_id,
             branches!inner(branch_name),
             products!inner(product_name),
-            customers!inner(segment_id)
+            customers!inner(segment)
           )
         `)
         .gte('transaction_date', startDate)
@@ -35,7 +35,7 @@ class FinancialReportService {
         transactionQuery = transactionQuery.eq('accounts.product_id', filters.product);
       }
       if (filters.segment && filters.segment !== 'all') {
-        transactionQuery = transactionQuery.eq('accounts.customers.segment_id', filters.segment);
+        transactionQuery = transactionQuery.eq('accounts.customers.segment', filters.segment);
       }
 
       const { data: transactionData, error: transactionError } = await transactionQuery;
@@ -59,7 +59,7 @@ class FinancialReportService {
           branch_id,
           product_id,
           customer_id,
-          customers!inner(segment_id)
+          customers!inner(segment)
         `)
         .eq('loan_status', 'ACTIVE')
         .lte('disbursement_date', endDate);
@@ -72,7 +72,7 @@ class FinancialReportService {
         loanQuery = loanQuery.eq('product_id', filters.product);
       }
       if (filters.segment && filters.segment !== 'all') {
-        loanQuery = loanQuery.eq('customers.segment_id', filters.segment);
+        loanQuery = loanQuery.eq('customers.segment', filters.segment);
       }
 
       const { data: loanData, error: loanError } = await loanQuery;
@@ -186,7 +186,7 @@ class FinancialReportService {
           ),
           branches!inner(branch_name),
           products!inner(product_name),
-          customers!inner(segment_id)
+          customers!inner(segment)
         `)
         .eq('account_status', 'ACTIVE');
 
@@ -198,7 +198,7 @@ class FinancialReportService {
         accountQuery = accountQuery.eq('product_id', filters.product);
       }
       if (filters.segment && filters.segment !== 'all') {
-        accountQuery = accountQuery.eq('customers.segment_id', filters.segment);
+        accountQuery = accountQuery.eq('customers.segment', filters.segment);
       }
 
       const { data: accountData, error: accountError } = await accountQuery;
@@ -220,7 +220,7 @@ class FinancialReportService {
             type_name,
             max_amount
           ),
-          customers!inner(segment_id)
+          customers!inner(segment)
         `)
         .in('loan_status', ['ACTIVE', 'DISBURSED'])
         .lte('disbursement_date', asOfDate);
@@ -233,7 +233,7 @@ class FinancialReportService {
         loanQuery = loanQuery.eq('product_id', filters.product);
       }
       if (filters.segment && filters.segment !== 'all') {
-        loanQuery = loanQuery.eq('customers.segment_id', filters.segment);
+        loanQuery = loanQuery.eq('customers.segment', filters.segment);
       }
 
       const { data: loanData, error: loanError } = await loanQuery;
@@ -340,7 +340,7 @@ class FinancialReportService {
             customer_id,
             branches!inner(branch_name),
             products!inner(product_name),
-            customers!inner(segment_id)
+            customers!inner(segment)
           )
         `)
         .gte('transaction_date', startDate)
@@ -354,7 +354,7 @@ class FinancialReportService {
         transactionQuery = transactionQuery.eq('accounts.product_id', filters.product);
       }
       if (filters.segment && filters.segment !== 'all') {
-        transactionQuery = transactionQuery.eq('accounts.customers.segment_id', filters.segment);
+        transactionQuery = transactionQuery.eq('accounts.customers.segment', filters.segment);
       }
 
       const { data: transactions, error: transactionError } = await transactionQuery;
@@ -472,7 +472,7 @@ class FinancialReportService {
             customer_id,
             branches!inner(branch_name),
             products!inner(product_name),
-            customers!inner(segment_id)
+            customers!inner(segment)
           )
         `)
         .gte('transaction_date', startDate)
@@ -486,7 +486,7 @@ class FinancialReportService {
         transactionQuery = transactionQuery.eq('accounts.product_id', filters.product);
       }
       if (filters.segment && filters.segment !== 'all') {
-        transactionQuery = transactionQuery.eq('accounts.customers.segment_id', filters.segment);
+        transactionQuery = transactionQuery.eq('accounts.customers.segment', filters.segment);
       }
 
       const { data: transactionData, error: transactionError } = await transactionQuery;


### PR DESCRIPTION
Fixes "column customers_2.segment_id does not exist" error by aligning segment column usage across UI and report services.

The error stemmed from a mismatch: the `customers` table has a `segment` column (e.g., 'RETAIL'), but the UI filtered using `segment_id` values (e.g., 'SEG001') from a different table. This PR updates report queries to use the correct `segment` column, hardcodes UI segment options to match the `customers` table, and adds a filter transformation to map `customerSegment` from the UI to `segment` for backend services.

---
<a href="https://cursor.com/background-agent?bcId=bc-92e641e4-bafb-45b8-97b3-fe471c222a97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92e641e4-bafb-45b8-97b3-fe471c222a97">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>