### PR TITLE
Fix missing addFooter function for reports

### DIFF
--- a/src/utils/reportGenerator.js
+++ b/src/utils/reportGenerator.js
@@ -136,6 +136,40 @@ class ReportGenerator {
     this.currentY = 45;
   }
 
+  // Helper to add footer
+  addFooter(doc = null, pageNumber = null) {
+    const pdfDoc = doc || this.doc;
+    if (!pdfDoc) return;
+
+    const pageHeight = pdfDoc.internal.pageSize.height;
+    const pageWidth = pdfDoc.internal.pageSize.width;
+    
+    // Add footer background
+    pdfDoc.setFillColor(...OSOL_BRAND.lightGray);
+    pdfDoc.rect(0, pageHeight - 20, pageWidth, 20, 'F');
+    
+    // Add footer text
+    pdfDoc.setTextColor(...OSOL_BRAND.textMuted);
+    pdfDoc.setFontSize(9);
+    pdfDoc.setFont('helvetica', 'normal');
+    
+    // Add generation date
+    const currentDate = format(new Date(), 'dd/MM/yyyy HH:mm');
+    pdfDoc.text(`Generated on: ${currentDate}`, 15, pageHeight - 10);
+    
+    // Add page number if provided
+    if (pageNumber) {
+      pdfDoc.text(`Page ${pageNumber}`, pageWidth - 30, pageHeight - 10);
+    }
+    
+    // Add copyright or company info
+    pdfDoc.setFontSize(8);
+    pdfDoc.text('© OSOL Financial Services - Confidential', pageWidth / 2, pageHeight - 10, { align: 'center' });
+    
+    // Reset text color
+    pdfDoc.setTextColor(...OSOL_BRAND.text);
+  }
+
   // Helper to format filters for display
   async formatFilters(filters) {
     if (!filters || Object.keys(filters).length === 0) return null;


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `addFooter` method to `ReportGenerator` class to resolve "this.addFooter is not a function" error.

---
<a href="https://cursor.com/background-agent?bcId=bc-667b52f4-58b8-4139-a573-01d72d65ec62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-667b52f4-58b8-4139-a573-01d72d65ec62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>