### PR TITLE
Fix toFixed type error in overview

### DIFF
--- a/src/pages/DashboardDetailNew.jsx
+++ b/src/pages/DashboardDetailNew.jsx
@@ -435,7 +435,7 @@ const DashboardDetailNew = () => {
               <StatCard
                 title="Total Customers"
                 value={(detailData.overview.totalCustomers || 0).toLocaleString()}
-                change={detailData.overview.change ? `${detailData.overview.change > 0 ? '+' : ''}${detailData.overview.change.toFixed(1)}%` : null}
+                change={detailData.overview.change ? `${detailData.overview.change > 0 ? '+' : ''}${typeof detailData.overview.change === 'string' ? parseFloat(detailData.overview.change).toFixed(1) : detailData.overview.change.toFixed(1)}%` : null}
                 trend={detailData.overview.trend}
                 description="All registered customers"
                 icon={Users}
@@ -468,7 +468,7 @@ const DashboardDetailNew = () => {
               <StatCard
                 title="Total Assets"
                 value={formatCurrency(detailData.overview.totalAssets || 0)}
-                change={detailData.overview.change ? `${detailData.overview.change > 0 ? '+' : ''}${detailData.overview.change.toFixed(1)}%` : null}
+                change={detailData.overview.change ? `${detailData.overview.change > 0 ? '+' : ''}${typeof detailData.overview.change === 'string' ? parseFloat(detailData.overview.change).toFixed(1) : detailData.overview.change.toFixed(1)}%` : null}
                 trend={detailData.overview.trend}
                 description="Combined deposits and loans"
                 icon={DollarSign}
@@ -537,7 +537,7 @@ const DashboardDetailNew = () => {
                     <StatCard
                       title="Total Customers"
                       value={(detailData.overview.totalCustomers || 0).toLocaleString()}
-                      change={detailData.overview.change ? `${detailData.overview.change > 0 ? '+' : ''}${detailData.overview.change.toFixed(1)}%` : null}
+                      change={detailData.overview.change ? `${detailData.overview.change > 0 ? '+' : ''}${typeof detailData.overview.change === 'string' ? parseFloat(detailData.overview.change).toFixed(1) : detailData.overview.change.toFixed(1)}%` : null}
                       trend={detailData.overview.trend}
                       description="All registered customers in the system"
                       icon={Users}
@@ -618,7 +618,7 @@ const DashboardDetailNew = () => {
                               </div>
                               <div className="flex justify-between">
                                 <span>Growth Rate:</span>
-                                <span className="font-medium">{detailData.overview.change ? `${detailData.overview.change.toFixed(1)}%` : '0%'}</span>
+                                <span className="font-medium">{detailData.overview.change ? `${typeof detailData.overview.change === 'string' ? parseFloat(detailData.overview.change).toFixed(1) : detailData.overview.change.toFixed(1)}%` : '0%'}</span>
                               </div>
                             </div>
                           </div>
@@ -652,7 +652,7 @@ const DashboardDetailNew = () => {
                     <StatCard
                       title="Total Assets"
                       value={formatCurrency(detailData.overview.totalAssets || 0)}
-                      change={detailData.overview.change ? `${detailData.overview.change > 0 ? '+' : ''}${detailData.overview.change.toFixed(1)}%` : null}
+                      change={detailData.overview.change ? `${detailData.overview.change > 0 ? '+' : ''}${typeof detailData.overview.change === 'string' ? parseFloat(detailData.overview.change).toFixed(1) : detailData.overview.change.toFixed(1)}%` : null}
                       trend={detailData.overview.trend}
                       description="Combined deposits and loans"
                       icon={DollarSign}

--- a/src/utils/dateFilters.js
+++ b/src/utils/dateFilters.js
@@ -94,5 +94,5 @@ export const getPreviousPeriodData = async (filters) => {
 
 export const calculatePercentageChange = (current, previous) => {
   if (previous === 0) return current > 0 ? 100 : 0;
-  return (((current - previous) / previous) * 100).toFixed(2);
+  return ((current - previous) / previous) * 100;
 };


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix `TypeError: toFixed is not a function` by ensuring percentage change values are numbers before formatting and by updating `calculatePercentageChange` to return a number.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `calculatePercentageChange` function was prematurely formatting its output to a string using `.toFixed(2)`. UI components then attempted to call `.toFixed(1)` on this string, causing the error. This PR updates the component to parse the string to a float if necessary, and modifies `calculatePercentageChange` to return a raw number, allowing components to format it as needed.

---
<a href="https://cursor.com/background-agent?bcId=bc-c39804af-f117-478c-9c4a-b6f0a83c6f0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c39804af-f117-478c-9c4a-b6f0a83c6f0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>