### PR TITLE
Handle invalid timestamp for data fetch

### DIFF
--- a/src/pages/Reports.jsx
+++ b/src/pages/Reports.jsx
@@ -283,8 +283,7 @@ export function ReportsResponsive() {
           case 'financial':
             data = await comprehensiveReportService.getFinancialReportData(
               selectedReport, 
-              dateRange?.from, 
-              dateRange?.to,
+              { startDate: dateRange?.from, endDate: dateRange?.to },
               {
                 filters: filters,
                 includeComparisons: true,
@@ -295,24 +294,21 @@ export function ReportsResponsive() {
           case 'regulatory':
             data = await comprehensiveReportService.getRegulatoryReportData(
               selectedReport,
-              dateRange?.from,
-              dateRange?.to,
+              { startDate: dateRange?.from, endDate: dateRange?.to },
               { filters: filters }
             );
             break;
           case 'customer':
             data = await comprehensiveReportService.getCustomerReportData(
               selectedReport,
-              dateRange?.from,
-              dateRange?.to,
+              { startDate: dateRange?.from, endDate: dateRange?.to },
               { filters: filters }
             );
             break;
           case 'risk':
             data = await comprehensiveReportService.getRiskReportData(
               selectedReport,
-              dateRange?.from,
-              dateRange?.to,
+              { startDate: dateRange?.from, endDate: dateRange?.to },
               { filters: filters }
             );
             break;


### PR DESCRIPTION
Fixes "invalid input syntax for type timestamp with time zone: 'undefined'" error by correctly passing date range objects to report service methods.

The `Reports.jsx` component was passing `dateRange.from` and `dateRange.to` as separate parameters, while the service methods expected a single `dateRange` object with `startDate` and `endDate` properties. This mismatch resulted in `undefined` values being sent to the database. The change updates the service calls to pass the date range as `{ startDate: dateRange?.from, endDate: dateRange?.to }`.

---
<a href="https://cursor.com/background-agent?bcId=bc-731b138e-c5b7-4763-8ae6-529d1b7f1aea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-731b138e-c5b7-4763-8ae6-529d1b7f1aea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>