### PR TITLE
Fix unrecognized time zone in reports

### DIFF
--- a/TIMEZONE_FIX_SUMMARY.md
+++ b/TIMEZONE_FIX_SUMMARY.md
@@ -1,0 +1,57 @@
+# Timezone Fix for Reports Module
+
+## Problem
+The error "time zone 'gmt+0300' not recognized" was occurring when generating reports. PostgreSQL doesn't recognize the timezone format "gmt+0300".
+
+## Root Cause
+The browser or some part of the application was sending dates with timezone format "gmt+0300" which PostgreSQL doesn't understand. PostgreSQL expects formats like:
+- `UTC+3` or `UTC-3`
+- `+03:00` or `-03:00`
+- Named timezones like `Asia/Riyadh`
+- ISO 8601 format with timezone
+
+## Solution Implemented
+
+### 1. Created Date Formatting Utilities (`src/utils/dateHelpers.js`)
+- `formatDateForDB()`: Converts any date to ISO 8601 format that PostgreSQL accepts
+- `formatDateRangeForDB()`: Formats date ranges for database queries
+- Automatically detects and fixes invalid timezone formats like "gmt+0300"
+
+### 2. Updated Comprehensive Report Service
+- Modified all report data methods to use the date formatting utilities
+- Ensures all dates are properly formatted before being sent to the database
+
+### 3. Added Supabase Request Interceptor
+- Updated `customFetch` in `src/lib/supabase.js` to intercept all requests
+- Automatically fixes timezone formats in:
+  - URL parameters
+  - Request body (recursively fixes all date fields)
+- Converts invalid formats to ISO 8601 format
+
+## How It Works
+
+1. When a date with format "gmt+0300" is detected:
+   - Extract the sign and offset (e.g., "+0300")
+   - Convert to proper format (e.g., "+03:00")
+   - Parse the date and convert to ISO 8601 format
+
+2. The fix is applied at multiple levels:
+   - Service layer: Before sending queries to the database
+   - HTTP layer: In the Supabase client's custom fetch function
+   - Ensures no invalid timezone format reaches PostgreSQL
+
+## Testing
+Run the test script to verify the fix:
+```bash
+node test_timezone_fix.js
+```
+
+## Impact
+- All report generation should now work without timezone errors
+- The fix is transparent to the rest of the application
+- No changes needed in UI components or other services
+
+## Future Considerations
+- Consider standardizing all date handling to use UTC internally
+- Add validation on the frontend to ensure dates are in proper format
+- Consider using a date library like date-fns consistently throughout the application

--- a/src/utils/dateHelpers.js
+++ b/src/utils/dateHelpers.js
@@ -1,0 +1,65 @@
+// Date formatting utilities for PostgreSQL compatibility
+
+/**
+ * Format a date for PostgreSQL, ensuring timezone compatibility
+ * PostgreSQL expects ISO 8601 format with timezone
+ * @param {Date|string} date - The date to format
+ * @returns {string} - ISO 8601 formatted date string
+ */
+export function formatDateForDB(date) {
+  if (!date) return null;
+  
+  // If it's already a string, try to parse it
+  if (typeof date === 'string') {
+    // Check if it contains invalid timezone format like 'gmt+0300'
+    if (date.toLowerCase().includes('gmt+') || date.toLowerCase().includes('gmt-')) {
+      // Extract the offset and convert to proper format
+      const match = date.match(/gmt([+-])(\d{2})(\d{2})?/i);
+      if (match) {
+        const sign = match[1];
+        const hours = match[2];
+        const minutes = match[3] || '00';
+        // Replace the invalid format with a valid one
+        date = date.replace(/gmt[+-]\d{2,4}/i, `${sign}${hours}:${minutes}`);
+      }
+    }
+    date = new Date(date);
+  }
+  
+  // Ensure we have a valid date
+  if (!(date instanceof Date) || isNaN(date.getTime())) {
+    console.error('Invalid date provided:', date);
+    return null;
+  }
+  
+  // Return ISO string which includes timezone information
+  return date.toISOString();
+}
+
+/**
+ * Format a date range for database queries
+ * @param {Object} dateRange - Object with from and to dates
+ * @returns {Object} - Formatted date range
+ */
+export function formatDateRangeForDB(dateRange) {
+  if (!dateRange) return null;
+  
+  return {
+    startDate: formatDateForDB(dateRange.from || dateRange.startDate),
+    endDate: formatDateForDB(dateRange.to || dateRange.endDate)
+  };
+}
+
+/**
+ * Ensure date is in UTC format
+ * @param {Date|string} date - The date to convert
+ * @returns {string} - UTC formatted date string
+ */
+export function toUTCString(date) {
+  if (!date) return null;
+  
+  const d = date instanceof Date ? date : new Date(date);
+  if (isNaN(d.getTime())) return null;
+  
+  return d.toISOString();
+}

--- a/test_timezone_fix.js
+++ b/test_timezone_fix.js
@@ -1,0 +1,77 @@
+// Test script for timezone fix
+
+import { formatDateForDB, formatDateRangeForDB } from './src/utils/dateHelpers.js';
+
+console.log('Testing timezone fix...\n');
+
+// Test cases
+const testCases = [
+  {
+    input: '2024-01-15T10:30:00 gmt+0300',
+    description: 'Date string with invalid gmt+0300 format'
+  },
+  {
+    input: '2024-01-15T10:30:00 GMT+0300',
+    description: 'Date string with uppercase GMT+0300'
+  },
+  {
+    input: '2024-01-15T10:30:00 gmt-0500',
+    description: 'Date string with negative offset'
+  },
+  {
+    input: new Date('2024-01-15T10:30:00+03:00'),
+    description: 'Valid Date object with timezone'
+  },
+  {
+    input: '2024-01-15T10:30:00Z',
+    description: 'Valid ISO string with Z timezone'
+  }
+];
+
+console.log('Individual date tests:');
+console.log('=====================');
+testCases.forEach(test => {
+  console.log(`\nInput: ${test.input}`);
+  console.log(`Description: ${test.description}`);
+  try {
+    const result = formatDateForDB(test.input);
+    console.log(`Output: ${result}`);
+    console.log('✅ Success');
+  } catch (error) {
+    console.log(`❌ Error: ${error.message}`);
+  }
+});
+
+// Test date range formatting
+console.log('\n\nDate range tests:');
+console.log('=================');
+const rangeTests = [
+  {
+    input: {
+      from: '2024-01-01T00:00:00 gmt+0300',
+      to: '2024-01-31T23:59:59 gmt+0300'
+    },
+    description: 'Date range with invalid timezone format'
+  },
+  {
+    input: {
+      startDate: new Date('2024-01-01'),
+      endDate: new Date('2024-01-31')
+    },
+    description: 'Date range with Date objects'
+  }
+];
+
+rangeTests.forEach(test => {
+  console.log(`\nInput: ${JSON.stringify(test.input)}`);
+  console.log(`Description: ${test.description}`);
+  try {
+    const result = formatDateRangeForDB(test.input);
+    console.log(`Output: ${JSON.stringify(result, null, 2)}`);
+    console.log('✅ Success');
+  } catch (error) {
+    console.log(`❌ Error: ${error.message}`);
+  }
+});
+
+console.log('\n\nTest completed!');


### PR DESCRIPTION
Fixes "time zone 'gmt+0300' not recognized" error by standardizing date formats for PostgreSQL.

The error occurred because PostgreSQL does not recognize the 'gmt+0300' timezone format. This PR introduces date formatting utilities and a Supabase request interceptor to convert all dates to a valid ISO 8601 format, ensuring compatibility with the database.

---
<a href="https://cursor.com/background-agent?bcId=bc-63ec7ff6-ad24-421e-a80c-f497c38a603c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63ec7ff6-ad24-421e-a80c-f497c38a603c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>