### PR TITLE
Build project with vite and fix import error

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -17,9 +17,9 @@
     <!-- Enhanced error handler to suppress extension errors -->
     <script src="/enhanced-error-handler.js"></script>
     <!-- Removed ethereum-conflict-resolver.js as it's not needed for a banking app -->
-    <script type="module" crossorigin src="/assets/index-CtuTGXX0.js"></script>
+    <script type="module" crossorigin src="/assets/index-BLj4JdaS.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/lucide-Dp-SfTrH.js">
-    <link rel="stylesheet" crossorigin href="/assets/index-DEn2J9Bu.css">
+    <link rel="stylesheet" crossorigin href="/assets/index-B7gG8SFB.css">
   </head>
   <body dir="ltr">
     <div id="root"></div>

--- a/src/components/ui/date-range-picker.jsx
+++ b/src/components/ui/date-range-picker.jsx
@@ -287,3 +287,6 @@ export function DatePicker({
     </Popover>
   );
 }
+
+// Alias for backward compatibility with existing imports
+export const DatePickerWithRange = DateRangePicker;


### PR DESCRIPTION
Add `DatePickerWithRange` export alias to fix build failure.

The build was failing because `ComparisonControls.jsx` and other files were importing `DatePickerWithRange`, but `date-range-picker.jsx` only exported `DateRangePicker`. This change provides the expected export for backward compatibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0f1c1b3-7157-4449-b8ce-0f3bc12b9346">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0f1c1b3-7157-4449-b8ce-0f3bc12b9346">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>