### PR TITLE
Add collection reports to sidebar and app

### DIFF
--- a/COLLECTION_REPORTS_INTEGRATION.md
+++ b/COLLECTION_REPORTS_INTEGRATION.md
@@ -1,0 +1,110 @@
+# Collection Reports Integration Confirmation
+
+## Overview
+All three collection report user stories have been successfully integrated into the OSOL banking system with proper sidebar navigation and routing.
+
+## What Was Updated
+
+### 1. Sidebar Navigation Updates
+The sidebar (`/src/components/layout/Sidebar.jsx`) has been reorganized to display all three collection reports at the same level for better visibility:
+
+- **Branch Level Report**
+  - Route: `/collection/branch-report`
+  - Icon: Building2
+  - Description: "Compare collection performance across branches, identify underperformers and top performers"
+  - Badge: NEW
+
+- **Product Level Report**
+  - Route: `/collection/product-report`
+  - Icon: Package
+  - Description: "Evaluate risk and collection performance by product for data-driven lending decisions"
+  - Badge: NEW
+
+- **Specialist Report**
+  - Route: `/collection/specialist-report`
+  - Icon: UserSearch
+  - Description: "Track communication activities, contact efforts, and promises to pay for each specialist"
+  - Badge: NEW
+
+### 2. Routes Confirmed in App.jsx
+All routes are properly configured in `/src/App.jsx`:
+```jsx
+<Route path="/collection/specialist-report" element={<SpecialistLevelReport />} />
+<Route path="/collection/branch-report" element={<BranchReportPage />} />
+<Route path="/collection/product-report" element={<ProductReportPage />} />
+```
+
+### 3. Page Components Structure
+Each report has the proper component structure:
+
+#### Branch Level Report
+- Page: `/src/pages/collection/BranchReport.jsx`
+- Component: `/src/components/dashboard/BranchLevelReport.jsx` (1,206 lines)
+- Service: `/src/services/branchReportService.js`
+
+#### Product Level Report
+- Page: `/src/pages/collection/ProductReport.jsx`
+- Component: `/src/components/dashboard/ProductLevelReport.jsx` (1,269 lines)
+- Service: `/src/services/productReportService.js`
+
+#### Specialist Report
+- Page: `/src/pages/SpecialistLevelReport.jsx` (2,402 lines - combined page/component)
+
+## Navigation Hierarchy
+All three reports are now easily accessible under the "Collection Dashboards" section in the sidebar:
+
+```
+COLLECTIONS
+└── Collection Dashboards (13 items)
+    ├── Collection Overview
+    ├── Daily Collection
+    ├── Digital Collection
+    ├── Early Warning
+    ├── Executive Collection
+    ├── Delinquency Executive
+    ├── Field Collection
+    ├── Officer Performance
+    ├── Sharia Compliance
+    ├── Vintage Analysis
+    ├── Branch Level Report (NEW)
+    ├── Product Level Report (NEW)
+    └── Specialist Report (NEW)
+```
+
+## Key Features Implemented
+
+### Branch Level Report
+- Weekly and daily data views
+- Branch KPIs (overdue portfolio, arrears ratio, collection rate)
+- Arrears aging bucket analysis
+- Branch comparison and ranking
+- Top/bottom performer identification
+
+### Product Level Report
+- Multi-product filtering
+- Product-specific KPIs
+- Comparative analysis across products
+- Trend analysis over time
+- SAMA compliance features
+
+### Specialist Report
+- Monthly communication logs
+- Call/SMS/Email tracking
+- Outcome logging system
+- Promise to pay management
+- Compliance with contact guidelines
+
+## Accessibility
+All reports are now:
+1. ✅ Visible in the sidebar navigation
+2. ✅ Properly routed in App.jsx
+3. ✅ Have descriptive text matching user story requirements
+4. ✅ Marked with "NEW" badges for easy identification
+5. ✅ Organized at the same hierarchical level for equal visibility
+
+## Next Steps
+1. Test each report to ensure functionality meets acceptance criteria
+2. Verify SAMA compliance features
+3. Test Arabic/English language support
+4. Ensure performance meets <3 second load time requirement
+5. Create user training materials for each report type

--- a/src/components/layout/Sidebar.jsx
+++ b/src/components/layout/Sidebar.jsx
@@ -211,34 +211,28 @@ const getNavigationItems = (t, useTranslation = false) => {
               description: getText('navigation.vintageAnalysisDesc', 'Portfolio aging analysis')
             },
             { 
+              title: getText('navigation.branchLevelReport', 'Branch Level Report'),
+              href: '/collection/branch-report',
+              icon: Building2,
+              badge: getText('common.new', 'NEW'),
+              badgeVariant: 'default',
+              description: getText('navigation.branchLevelReportDesc', 'Compare collection performance across branches, identify underperformers and top performers')
+            },
+            {
+              title: getText('navigation.productLevelReport', 'Product Level Report'),
+              href: '/collection/product-report',
+              icon: Package,
+              badge: getText('common.new', 'NEW'),
+              badgeVariant: 'default',
+              description: getText('navigation.productLevelReportDesc', 'Evaluate risk and collection performance by product for data-driven lending decisions')
+            },
+            { 
               title: getText('navigation.specialistReport', 'Specialist Report'), 
               href: '/collection/specialist-report', 
               icon: UserSearch, 
               badge: getText('common.new', 'NEW'),
               badgeVariant: 'default',
               description: getText('navigation.specialistReportDesc', 'Track communication activities, contact efforts, and promises to pay for each specialist')
-            },
-            {
-              title: getText('navigation.collectionReports', 'Collection Reports'),
-              icon: FileText,
-              items: [
-                {
-                  title: getText('navigation.branchLevelReport', 'Branch Level Report'),
-                  href: '/collection/branch-report',
-                  icon: Building2,
-                  badge: getText('common.new', 'NEW'),
-                  badgeVariant: 'default',
-                  description: getText('navigation.branchLevelReportDesc', 'Compare collection performance across branches, identify underperformers and top performers')
-                },
-                {
-                  title: getText('navigation.productLevelReport', 'Product Level Report'),
-                  href: '/collection/product-report',
-                  icon: Package,
-                  badge: getText('common.new', 'NEW'),
-                  badgeVariant: 'default',
-                  description: getText('navigation.productLevelReportDesc', 'Evaluate risk and collection performance by product for data-driven lending decisions')
-                }
-              ]
             },
           ],
         },


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Reorganize sidebar navigation to display all collection reports at the same level for improved visibility and consistent access.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the Branch Level Report and Product Level Report were nested under a "Collection Reports" submenu, while the Specialist Report was at the main level. This change brings all three reports to the same hierarchical level under "Collection Dashboards."

---
<a href="https://cursor.com/background-agent?bcId=bc-17c5d989-eeb8-4a8b-8380-fa7fe1f7d1ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-17c5d989-eeb8-4a8b-8380-fa7fe1f7d1ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>