### PR TITLE
Add branch and product reports to sidebar

### DIFF
--- a/src/components/layout/ModernSidebar.jsx
+++ b/src/components/layout/ModernSidebar.jsx
@@ -28,7 +28,8 @@ import {
   Moon,
   Sun,
   Zap,
-  User
+  User,
+  Package
 } from 'lucide-react';
 
 const ModernSidebar = () => {
@@ -112,6 +113,18 @@ const ModernSidebar = () => {
           label: t('sidebar.collectionCases'),
           path: '/collection/cases',
           icon: FileText
+        },
+        {
+          id: 'branch-report',
+          label: t('sidebar.branchLevelReport'),
+          path: '/collection/branch-report',
+          icon: Building2
+        },
+        {
+          id: 'product-report',
+          label: t('sidebar.productLevelReport'),
+          path: '/collection/product-report',
+          icon: Package
         }
       ]
     },


### PR DESCRIPTION
Add Branch Report and Product Report to ModernSidebar navigation as they were previously missing.

The pages were not visible in the sidebar because they were not included in the `ModernSidebar.jsx` component, which is the active sidebar. This PR also imports the `Package` icon required for the Product Report entry.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2da0f9b-35e2-4709-85a7-039fba5ec205">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2da0f9b-35e2-4709-85a7-039fba5ec205">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>