### PR TITLE
Fix sidebar label

### DIFF
--- a/public/locales/ar/translation.json
+++ b/public/locales/ar/translation.json
@@ -1112,6 +1112,8 @@
     "fieldCollection": "التحصيل الميداني",
     "digitalCollection": "التحصيل الرقمي",
     "collectionCases": "حالات التحصيل",
+    "branchLevelReport": "تقرير مستوى الفرع",
+    "productLevelReport": "تقرير مستوى المنتج",
     "delinquency": "المتأخرات",
     "delinquencyExecutive": "المتأخرات التنفيذية",
     "earlyWarning": "الإنذار المبكر",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1163,6 +1163,8 @@
     "fieldCollection": "Field Collection",
     "digitalCollection": "Digital Collection",
     "collectionCases": "Collection Cases",
+    "branchLevelReport": "Branch Level Report",
+    "productLevelReport": "Product Level Report",
     "delinquency": "Delinquency",
     "delinquencyExecutive": "Delinquency Executive",
     "earlyWarning": "Early Warning",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add missing sidebar translation keys for branch and product level reports to display labels correctly.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The sidebar was attempting to display `sidebar.branchLevelReport` and `sidebar.productLevelReport`, but these keys were not defined under the `sidebar` section in the translation files, leading to raw key display. This PR adds the correct definitions.

---
<a href="https://cursor.com/background-agent?bcId=bc-12830e64-ef81-4c8d-99ea-4bf04a0bc541">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12830e64-ef81-4c8d-99ea-4bf04a0bc541">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>