### PR TITLE
Fix sidebar rtl on arabic language switch

### DIFF
--- a/src/components/layout/ModernSidebar.jsx
+++ b/src/components/layout/ModernSidebar.jsx
@@ -374,7 +374,8 @@ const ModernSidebar = ({ isMobile }) => {
         className={cn(
           "fixed lg:relative z-50 lg:z-0",
           "h-full bg-white dark:bg-gray-900",
-          "border-e border-gray-200 dark:border-gray-700",
+          isRTL ? "border-l" : "border-r",
+          "border-gray-200 dark:border-gray-700",
           "transition-all duration-300 ease-in-out",
           "flex flex-col",
           isOpen ? "w-64" : "w-0 lg:w-20",

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,7 @@
 @import './styles/new-sidebar.css';
 @import './styles/mobile-sidebar.css';
 @import './styles/sidebar.css';
+@import './styles/modern-sidebar-rtl.css';
 @import './styles/print.css';
 @import './styles/mobile-reports.css';
 @import './styles/rtl.css';

--- a/src/styles/modern-sidebar-rtl.css
+++ b/src/styles/modern-sidebar-rtl.css
@@ -1,0 +1,129 @@
+/* Modern Sidebar RTL Fixes */
+
+/* When RTL, the sidebar should be on the right side */
+[dir="rtl"] aside.fixed {
+  left: auto !important;
+  right: 0 !important;
+}
+
+/* Fix the transform for RTL when sidebar is closed on mobile */
+[dir="rtl"] aside.fixed.translate-x-full {
+  transform: translateX(100%) !important;
+}
+
+[dir="rtl"] aside.fixed.-translate-x-full {
+  transform: translateX(-100%) !important;
+}
+
+/* Ensure proper border positioning in RTL */
+[dir="rtl"] .border-e {
+  border-right-width: 0;
+  border-left-width: 1px;
+}
+
+[dir="rtl"] .border-l {
+  border-left-width: 1px;
+}
+
+[dir="rtl"] .border-r {
+  border-right-width: 0;
+}
+
+/* Fix main content area margin in RTL */
+[dir="rtl"] .lg\:ml-20 {
+  margin-left: 0;
+  margin-right: 5rem;
+}
+
+[dir="rtl"] .lg\:ml-64 {
+  margin-left: 0;
+  margin-right: 16rem;
+}
+
+/* Fix overlay positioning for RTL */
+[dir="rtl"] .fixed.inset-0 {
+  right: 0;
+  left: 0;
+}
+
+/* Ensure flex-row-reverse works properly in the main layout */
+[dir="rtl"] .flex {
+  direction: rtl;
+}
+
+[dir="rtl"] .flex-row-reverse {
+  flex-direction: row-reverse !important;
+}
+
+/* Fix sidebar positioning on desktop */
+@media (min-width: 1024px) {
+  [dir="rtl"] aside.lg\:relative {
+    position: relative !important;
+    right: auto !important;
+    left: auto !important;
+    transform: none !important;
+  }
+}
+
+/* Fix chevron rotation in RTL */
+[dir="rtl"] .rotate-180 {
+  transform: rotate(-180deg);
+}
+
+/* Ensure text alignment in sidebar items */
+[dir="rtl"] .text-start {
+  text-align: right !important;
+}
+
+/* Fix padding and margins for RTL */
+[dir="rtl"] .pl-4 {
+  padding-left: 0;
+  padding-right: 1rem;
+}
+
+[dir="rtl"] .pr-4 {
+  padding-right: 0;
+  padding-left: 1rem;
+}
+
+[dir="rtl"] .ml-2 {
+  margin-left: 0;
+  margin-right: 0.5rem;
+}
+
+[dir="rtl"] .mr-2 {
+  margin-right: 0;
+  margin-left: 0.5rem;
+}
+
+/* Fix sidebar width transitions */
+[dir="rtl"] aside {
+  transition-property: width, transform;
+}
+
+/* Ensure sidebar stays on the right in RTL mode on larger screens */
+@media (min-width: 1024px) {
+  [dir="rtl"] .flex-row-reverse > aside:first-child {
+    order: 2;
+  }
+  
+  [dir="rtl"] .flex-row-reverse > div:last-child {
+    order: 1;
+  }
+}
+
+/* Fix mobile sidebar slide direction */
+[dir="rtl"] aside.w-0:not(.lg\:w-20) {
+  transform: translateX(100%);
+}
+
+[dir="rtl"] aside.w-64 {
+  transform: translateX(0);
+}
+
+/* Override any conflicting transforms on desktop */
+@media (min-width: 1024px) {
+  [dir="rtl"] aside {
+    transform: none !important;
+  }
+}


### PR DESCRIPTION
Fixes Modern Sidebar RTL layout to correctly position and animate when language is Arabic.

The sidebar was not visually switching to RTL despite the `dir="rtl"` attribute being set. This was due to insufficient RTL-specific CSS for positioning, borders, and mobile animations, which required explicit overrides and adjustments for right-to-left display.

---
<a href="https://cursor.com/background-agent?bcId=bc-51d3fbc0-450e-450a-a3c1-562a3a090a9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-51d3fbc0-450e-450a-a3c1-562a3a090a9a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>