### PR TITLE
Initialize app and handle report generation error

### DIFF
--- a/FIX_AUTOTABLE_ERROR.md
+++ b/FIX_AUTOTABLE_ERROR.md
@@ -1,0 +1,55 @@
+# Fix for jsPDF autoTable Error
+
+## Issue
+The error `i.autoTable is not a function` was occurring when trying to generate PDF reports from the executive dashboard.
+
+## Root Cause
+The `jspdf-autotable` plugin was imported as a side effect:
+```javascript
+import 'jspdf-autotable';
+```
+
+This approach relies on the plugin automatically adding the `autoTable` method to jsPDF instances, but this wasn't working correctly in the production build.
+
+## Solution
+Changed to use the named import approach:
+
+1. Updated the import statement in `/workspace/src/services/dashboardButtonService.js`:
+```javascript
+// Before:
+import 'jspdf-autotable';
+
+// After:
+import autoTable from 'jspdf-autotable';
+```
+
+2. Updated all calls from `pdf.autoTable(...)` to `autoTable(pdf, ...)`:
+```javascript
+// Before:
+pdf.autoTable({
+  startY: yPosition,
+  head: [kpiData[0]],
+  body: kpiData.slice(1),
+  theme: 'grid',
+  styles: { fontSize: 10 },
+  headStyles: { fillColor: [67, 56, 202] }
+});
+
+// After:
+autoTable(pdf, {
+  startY: yPosition,
+  head: [kpiData[0]],
+  body: kpiData.slice(1),
+  theme: 'grid',
+  styles: { fontSize: 10 },
+  headStyles: { fillColor: [67, 56, 202] }
+});
+```
+
+## Files Modified
+- `/workspace/src/services/dashboardButtonService.js` - Fixed import and all autoTable calls
+
+## Additional Notes
+- The `reportGenerator.js` file was already using the correct import approach
+- The build now completes successfully
+- To deploy, run: `pnpm run build` followed by your deployment command

--- a/dist/index.html
+++ b/dist/index.html
@@ -17,7 +17,7 @@
     <!-- Enhanced error handler to suppress extension errors -->
     <script src="/enhanced-error-handler.js"></script>
     <!-- Removed ethereum-conflict-resolver.js as it's not needed for a banking app -->
-    <script type="module" crossorigin src="/assets/index-aMHb-PyV.js"></script>
+    <script type="module" crossorigin src="/assets/index-Ch9FPa8e.js"></script>
     <link rel="modulepreload" crossorigin href="/assets/lucide-BeJV5ir5.js">
     <link rel="stylesheet" crossorigin href="/assets/index-erQdZKHV.css">
   </head>

--- a/node_modules/.bin/autoprefixer
+++ b/node_modules/.bin/autoprefixer
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/autoprefixer" "$@"
 else
-  exec node  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
+  exec node  "$basedir/../.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/autoprefixer" "$@"
 fi

--- a/node_modules/.bin/eslint
+++ b/node_modules/.bin/eslint
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../eslint/bin/eslint.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/eslint.js" "$@"
 else
-  exec node  "$basedir/../eslint/bin/eslint.js" "$@"
+  exec node  "$basedir/../.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/eslint.js" "$@"
 fi

--- a/node_modules/.bin/tailwind
+++ b/node_modules/.bin/tailwind
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 else
-  exec node  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec node  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 fi

--- a/node_modules/.bin/tailwindcss
+++ b/node_modules/.bin/tailwindcss
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 else
-  exec node  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec node  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 fi

--- a/node_modules/.bin/vite
+++ b/node_modules/.bin/vite
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../vite/bin/vite.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/vite.js" "$@"
 else
-  exec node  "$basedir/../vite/bin/vite.js" "$@"
+  exec node  "$basedir/../.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/vite.js" "$@"
 fi

--- a/src/services/dashboardButtonService.js
+++ b/src/services/dashboardButtonService.js
@@ -2,7 +2,7 @@
 import { saveAs } from 'file-saver';
 import * as XLSX from 'xlsx';
 import jsPDF from 'jspdf';
-import 'jspdf-autotable';
+import autoTable from 'jspdf-autotable';
 import html2canvas from 'html2canvas';
 
 export class DashboardButtonService {
@@ -150,7 +150,7 @@ export class DashboardButtonService {
       ['NPL Ratio', `${data.npl?.ratio || 0}%`, `${data.npl?.previousRatio || 0}%`, data.npl?.change || '0%']
     ];
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: yPosition,
       head: [kpiData[0]],
       body: kpiData.slice(1),
@@ -180,7 +180,7 @@ export class DashboardButtonService {
       ['Compliance Risk', `${data.riskScores?.compliance || 0}%`, this.getRiskStatus(data.riskScores?.compliance)]
     ];
 
-    pdf.autoTable({
+    autoTable(pdf, {
       startY: yPosition,
       head: [riskData[0]],
       body: riskData.slice(1),
@@ -213,7 +213,7 @@ export class DashboardButtonService {
         ])
       ];
 
-      pdf.autoTable({
+      autoTable(pdf, {
         startY: yPosition,
         head: [portfolioTableData[0]],
         body: portfolioTableData.slice(1),


### PR DESCRIPTION
Fixes PDF report generation by correctly importing and using the `jspdf-autotable` plugin.

The `jspdf-autotable` plugin's `autoTable` method was not available on the jsPDF instance (`pdf.autoTable`) in production builds due to its side-effect import. This PR changes the import to a named import (`import autoTable from 'jspdf-autotable';`) and updates all calls to `autoTable(pdf, ...)`, ensuring the function is correctly used. It also installs a missing `tailwindcss-rtl` dependency that caused build failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f4b7891-5c5a-44b3-9a01-270f851dba52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f4b7891-5c5a-44b3-9a01-270f851dba52">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>