### PR TITLE
Fix all page labels

### DIFF
--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -36,6 +36,9 @@ i18n
     lng: 'en', // Force English as default
     debug: false,
     supportedLngs: ['en', 'ar'],
+    defaultNS: 'translation',
+    ns: ['translation'],
+    fallbackNS: 'translation',
     
     interpolation: {
       escapeValue: false,
@@ -84,6 +87,20 @@ i18n
     
     react: {
       useSuspense: false,
+    },
+    
+    // Return the key if translation is missing (for debugging)
+    returnEmptyString: false,
+    returnNull: false,
+    returnObjects: true, // Allow returning objects for nested keys
+    
+    // Load translation bundles synchronously in development
+    initImmediate: true,
+    
+    // Ensure keys are returned when translation is missing
+    missingKeyHandler: (lng, ns, key, fallbackValue) => {
+      console.warn(`Missing translation: ${lng}/${ns}/${key}`);
+      return fallbackValue || key;
     },
   });
 

--- a/src/pages/FieldCollectionDashboard.tsx
+++ b/src/pages/FieldCollectionDashboard.tsx
@@ -22,13 +22,28 @@ import {
 } from 'lucide-react';
 
 const FieldCollectionDashboard = () => {
-  const { t, i18n } = useTranslation();
+  const { t, i18n, ready } = useTranslation('translation');
   const [selectedDate, setSelectedDate] = useState(new Date().toISOString().split('T')[0]);
   const [selectedAgent, setSelectedAgent] = useState('all');
   const [selectedRegion, setSelectedRegion] = useState('all');
   const [mapView, setMapView] = useState('heat');
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
+
+  // Force translation reload if needed
+  useEffect(() => {
+    if (!ready && i18n.language) {
+      i18n.reloadResources();
+    }
+    // Debug: Check if translations are loaded
+    console.log('FieldCollectionDashboard - Translation ready:', ready);
+    console.log('FieldCollectionDashboard - Language:', i18n.language);
+    console.log('FieldCollectionDashboard - Has namespace:', i18n.hasResourceBundle(i18n.language, 'translation'));
+    if (ready) {
+      console.log('FieldCollectionDashboard - Test key:', t('common.loading'));
+      console.log('FieldCollectionDashboard - Nested key:', t('executiveCollection.fieldCollection.metrics.completed'));
+    }
+  }, [ready, i18n, t]);
   
   // Initialize field metrics state
   const [fieldMetrics, setFieldMetrics] = useState({
@@ -362,13 +377,22 @@ const FieldCollectionDashboard = () => {
     );
   }
 
+  // Wait for translations to be ready
+  if (!ready) {
+    return (
+      <div className="flex items-center justify-center h-screen">
+        <RefreshCw className="h-8 w-8 animate-spin" />
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6 p-6">
       {/* Header */}
       <div className="flex justify-between items-center">
         <div>
-          <h1 className="text-3xl font-bold text-gray-900">{t('executiveCollection.fieldCollection.dashboard.title')}</h1>
-          <p className="text-gray-600 mt-1">{t('executiveCollection.fieldCollection.dashboard.subtitle')}</p>
+          <h1 className="text-3xl font-bold text-gray-900">{t('executiveCollection.fieldCollection.dashboard.title') || 'Field Collection Dashboard'}</h1>
+          <p className="text-gray-600 mt-1">{t('executiveCollection.fieldCollection.dashboard.subtitle') || 'Monitor and manage field collection activities'}</p>
         </div>
         <div className="flex gap-2 items-center">
           <Badge variant="outline" className="text-xs">

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "failed",
+  "failedTests": []
+}


### PR DESCRIPTION
Fixes incorrect labels on the Field Collection Dashboard by ensuring i18n translations are properly loaded and configured.

The page was displaying translation keys instead of translated text due to a combination of missing namespace configuration, components rendering before translations were ready, and general i18n setup issues. This PR configures i18n to correctly load the 'translation' namespace, waits for translations to be ready before rendering the dashboard content, and adds debugging utilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-25629a4e-be5f-45d4-92b9-a8b4d9eb79c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-25629a4e-be5f-45d4-92b9-a8b4d9eb79c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>