### PR TITLE
Build project with json syntax error

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -2137,8 +2137,7 @@
         "complianceRate": "Compliance Rate",
         "completed": "Completed"
       }
-    }
-  },
+    },
   "dailyCollectionDashboard": {
     "title": "Daily Collection Dashboard",
     "subtitle": "Real-time monitoring of collection activities",


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove an extra closing brace in `translation.json` to fix JSON parsing errors during build.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The build was failing due to an "Extra data" JSON parsing error at line 2141 of `public/locales/en/translation.json`. This was caused by an extraneous closing brace that prematurely closed the root JSON object. Removing this extra brace resolves the syntax error and allows the build to proceed.

---
<a href="https://cursor.com/background-agent?bcId=bc-4d87aee2-dce6-4190-a3f1-f9d60ea7b0fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4d87aee2-dce6-4190-a3f1-f9d60ea7b0fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>