### PR TITLE
Update pnpm lockfile for build

### DIFF
--- a/node_modules/.bin/autoprefixer
+++ b/node_modules/.bin/autoprefixer
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/autoprefixer" "$@"
+  exec "$basedir/node"  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
 else
-  exec node  "$basedir/../.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/autoprefixer" "$@"
+  exec node  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
 fi

--- a/node_modules/.bin/eslint
+++ b/node_modules/.bin/eslint
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/eslint.js" "$@"
+  exec "$basedir/node"  "$basedir/../eslint/bin/eslint.js" "$@"
 else
-  exec node  "$basedir/../.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/eslint.js" "$@"
+  exec node  "$basedir/../eslint/bin/eslint.js" "$@"
 fi

--- a/node_modules/.bin/tailwind
+++ b/node_modules/.bin/tailwind
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../tailwindcss/lib/cli.js" "$@"
 else
-  exec node  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
+  exec node  "$basedir/../tailwindcss/lib/cli.js" "$@"
 fi

--- a/node_modules/.bin/tailwindcss
+++ b/node_modules/.bin/tailwindcss
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../tailwindcss/lib/cli.js" "$@"
 else
-  exec node  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
+  exec node  "$basedir/../tailwindcss/lib/cli.js" "$@"
 fi

--- a/node_modules/.bin/vite
+++ b/node_modules/.bin/vite
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/vite.js" "$@"
+  exec "$basedir/node"  "$basedir/../vite/bin/vite.js" "$@"
 else
-  exec node  "$basedir/../.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/vite.js" "$@"
+  exec node  "$basedir/../vite/bin/vite.js" "$@"
 fi

--- a/node_modules/.pnpm/lock.yaml
+++ b/node_modules/.pnpm/lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.7
         version: 4.1.7(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1667,6 +1670,9 @@ packages:
   base64-arraybuffer@1.0.2:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
     engines: {node: '>= 0.6.0'}
+
+  bcryptjs@2.4.3:
+    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -4749,6 +4755,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   base64-arraybuffer@1.0.2: {}
+
+  bcryptjs@2.4.3: {}
 
   binary-extensions@2.3.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.1.7
         version: 4.1.7(vite@6.3.5(@types/node@24.1.0)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+      bcryptjs:
+        specifier: ^2.4.3
+        version: 2.4.3
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -1667,6 +1670,9 @@ packages:
   base64-arraybuffer@1.0.2:
     resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
     engines: {node: '>= 0.6.0'}
+
+  bcryptjs@2.4.3:
+    resolution: {integrity: sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -4749,6 +4755,8 @@ snapshots:
   balanced-match@1.0.2: {}
 
   base64-arraybuffer@1.0.2: {}
+
+  bcryptjs@2.4.3: {}
 
   binary-extensions@2.3.0: {}
 


### PR DESCRIPTION
Update `pnpm-lock.yaml` to resolve `ERR_PNPM_OUTDATED_LOCKFILE` and fix Vercel build.

---
<a href="https://cursor.com/background-agent?bcId=bc-19b12610-ffc5-44ee-be6d-6dc08c4ab733">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19b12610-ffc5-44ee-be6d-6dc08c4ab733">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

