### PR TITLE
Clone and install project dependencies

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -36,8 +36,6 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),
-        // Ensure xlsx resolves to ESM build
-        "xlsx": path.resolve(__dirname, "./node_modules/xlsx/dist/xlsx.mjs"),
         // Ensure jspdf resolves correctly
         "jspdf": path.resolve(__dirname, "./node_modules/jspdf/dist/jspdf.es.min.js"),
         // Ensure jspdf-autotable resolves correctly
@@ -81,7 +79,7 @@ export default defineConfig(({ mode }) => {
       }
     },
     optimizeDeps: {
-      include: ['lucide-react', '@hello-pangea/dnd', 'pdfjs-dist', 'xlsx/dist/xlsx.mjs', 'jspdf', 'jspdf-autotable', 'file-saver', 'html2canvas'],
+      include: ['lucide-react', '@hello-pangea/dnd', 'pdfjs-dist', 'xlsx', 'jspdf', 'jspdf-autotable', 'file-saver', 'html2canvas'],
       // Force re-optimization in development
       force: true
     }


### PR DESCRIPTION
Fixes Vite build failure by correcting `xlsx` resolution in `vite.config.js`.

The previous Vite alias for `xlsx` pointed to a non-existent path (`xlsx/dist/xlsx.mjs`), which caused Rollup to fail during the build process, especially with pnpm's module resolution. Removing this incorrect alias and updating `optimizeDeps.include` allows Vite to correctly resolve the `xlsx` package.

---
<a href="https://cursor.com/background-agent?bcId=bc-6f01fc9f-96df-4403-b8da-ef47f863b94b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6f01fc9f-96df-4403-b8da-ef47f863b94b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

