### PR TITLE
Changes from background agent bc-bf603c5e-cf45-4c2e-bb25-a141e92fe70a

### DIFF
--- a/public/locales/ar/translation.json
+++ b/public/locales/ar/translation.json
@@ -133,6 +133,7 @@
       "collections": "التحصيل",
       "bankingOperations": "العمليات المصرفية"
     },
+    "banking": "الخدمات المصرفية",
     "overview": "نظرة عامة",
     "mainDashboard": "لوحة التحكم الرئيسية",
     "dashboards": "لوحات التحكم",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -128,6 +128,7 @@
       "collections": "COLLECTIONS",
       "bankingOperations": "BANKING OPERATIONS"
     },
+    "banking": "Banking",
     "overview": "Overview",
     "mainDashboard": "Main Dashboard",
     "dashboards": "Dashboards",

--- a/src/pages/Accounts.jsx
+++ b/src/pages/Accounts.jsx
@@ -82,14 +82,14 @@ export function Accounts() {
         .from(TABLES.ACCOUNTS)
         .select(`
           *,
-          kastle_banking.customers!customer_id (
+          customers!customer_id (
             customer_id,
             first_name,
             last_name,
             email,
             phone_number
           ),
-          kastle_banking.account_types!account_type_id (
+          account_types!account_type_id (
             type_id,
             type_code,
             type_name,
@@ -103,7 +103,7 @@ export function Accounts() {
       }
       
       if (filterType !== 'all') {
-        query = query.eq('kastle_banking.account_types.account_category', filterType.toUpperCase());
+        query = query.eq('account_types.account_category', filterType.toUpperCase());
       }
 
       const { data, error } = await query;
@@ -166,7 +166,7 @@ export function Accounts() {
         .from(TABLES.ACCOUNTS)
         .select(`
           account_type_id,
-          kastle_banking.account_types!account_type_id (
+          account_types!account_type_id (
             type_name,
             account_category
           )
@@ -174,7 +174,7 @@ export function Accounts() {
         .eq('account_status', 'ACTIVE');
 
       const typeCounts = typeData?.reduce((acc, curr) => {
-        const typeName = curr.kastle_banking?.account_types?.type_name || 'Unknown';
+        const typeName = curr.account_types?.type_name || 'Unknown';
         acc[typeName] = (acc[typeName] || 0) + 1;
         return acc;
       }, {});
@@ -503,7 +503,7 @@ export function Accounts() {
                         </TableCell>
                         <TableCell>
                           <Badge variant="outline">
-                            {account.kastle_banking?.account_types?.type_name || account.account_type?.replace('_', ' ')}
+                            {account.account_types?.type_name || account.account_type?.replace('_', ' ') }
                           </Badge>
                         </TableCell>
                         <TableCell>SAR {parseFloat(account.current_balance).toLocaleString()}</TableCell>

--- a/src/pages/DashboardDetailNew.jsx
+++ b/src/pages/DashboardDetailNew.jsx
@@ -1310,10 +1310,10 @@ const DashboardDetailNew = () => {
                       data={detailData.raw.accounts.slice(0, 20)}
                       columns={[
                         { header: 'Account Number', accessor: (row) => row.account_number },
-                        { header: 'Customer', accessor: (row) => `${row.kastle_banking?.customers?.first_name || ''} ${row.kastle_banking?.customers?.last_name || ''}`.trim() || 'N/A' },
+                        { header: 'Customer', accessor: (row) => `${row.customers?.first_name || ''} ${row.customers?.last_name || ''}`.trim() || 'N/A' },
                         { header: 'Type', accessor: (row) => (
                           <Badge variant="outline">
-                            {row.kastle_banking?.account_types?.type_name || 'Unknown'}
+                                                          {row.account_types?.type_name || 'Unknown'}
                           </Badge>
                         )},
                         { header: 'Balance', accessor: (row) => formatCurrency(row.current_balance || 0) },

--- a/src/pages/Transactions.jsx
+++ b/src/pages/Transactions.jsx
@@ -135,9 +135,9 @@ export function Transactions() {
         .from(TABLES.TRANSACTIONS)
         .select(`
           *,
-          kastle_banking.accounts!account_number (
+          accounts!account_number (
             account_number,
-            kastle_banking.customers!customer_id (
+            customers!customer_id (
               first_name,
               last_name
             )

--- a/src/services/enhancedDashboardDetailsService.js
+++ b/src/services/enhancedDashboardDetailsService.js
@@ -262,7 +262,7 @@ export const enhancedDashboardDetailsService = {
         .from(TABLES.ACCOUNTS)
         .select(`
           *,
-          kastle_banking.account_types!account_type_id (
+          account_types!account_type_id (
             type_name,
             account_category
           )
@@ -293,7 +293,7 @@ export const enhancedDashboardDetailsService = {
       // Account type breakdown for overview
       const accountTypes = {};
       accounts.forEach(account => {
-        const category = account.kastle_banking?.account_types?.account_category || 'Unknown';
+        const category = account.account_types?.account_category || 'Unknown';
         accountTypes[category] = (accountTypes[category] || 0) + 1;
       });
 
@@ -352,16 +352,16 @@ export const enhancedDashboardDetailsService = {
         newAccountsThisMonth: newAccountsThisMonth || 0,
         // Additional banking-specific metrics
         savingsAccounts: accounts.filter(acc => 
-          acc.kastle_banking?.account_types?.account_category === 'SAVINGS'
+          acc.account_types?.account_category === 'SAVINGS'
         ).length,
         currentAccounts: accounts.filter(acc => 
-          acc.kastle_banking?.account_types?.account_category === 'CURRENT'
+          acc.account_types?.account_category === 'CURRENT'
         ).length,
         totalSavingsBalance: accounts
-          .filter(acc => acc.kastle_banking?.account_types?.account_category === 'SAVINGS')
+          .filter(acc => acc.account_types?.account_category === 'SAVINGS')
           .reduce((sum, acc) => sum + parseFloat(acc.current_balance || 0), 0),
         totalCurrentBalance: accounts
-          .filter(acc => acc.kastle_banking?.account_types?.account_category === 'CURRENT')
+          .filter(acc => acc.account_types?.account_category === 'CURRENT')
           .reduce((sum, acc) => sum + parseFloat(acc.current_balance || 0), 0)
       };
     } catch (error) {
@@ -864,11 +864,11 @@ export const enhancedDashboardDetailsService = {
         .from(TABLES.ACCOUNTS)
         .select(`
           *,
-          kastle_banking.account_types!account_type_id (
+          account_types!account_type_id (
             type_name,
             account_category
           ),
-          kastle_banking.customers!customer_id (
+          customers!customer_id (
             customer_id,
             first_name,
             last_name
@@ -894,7 +894,7 @@ export const enhancedDashboardDetailsService = {
       // Breakdown by account category
       const byCategory = {};
       accounts.forEach(account => {
-        const category = account.kastle_banking?.account_types?.account_category || 'Unknown';
+        const category = account.account_types?.account_category || 'Unknown';
         if (!byCategory[category]) byCategory[category] = 0;
         byCategory[category] += parseFloat(account.current_balance || 0);
       });
@@ -902,7 +902,7 @@ export const enhancedDashboardDetailsService = {
       // Breakdown by account type
       const byAccountType = {};
       accounts.forEach(account => {
-        const type = account.kastle_banking?.account_types?.type_name || 'Unknown';
+        const type = account.account_types?.type_name || 'Unknown';
         if (!byAccountType[type]) byAccountType[type] = 0;
         byAccountType[type] += parseFloat(account.current_balance || 0);
       });
@@ -1028,11 +1028,11 @@ export const enhancedDashboardDetailsService = {
         .from(TABLES.ACCOUNTS)
         .select(`
           *,
-          kastle_banking.account_types!account_type_id (
+          account_types!account_type_id (
             type_name,
             account_category
           ),
-          kastle_banking.customers!customer_id (
+          customers!customer_id (
             customer_id,
             first_name,
             last_name,


### PR DESCRIPTION
Fixes Supabase query errors on banking detail pages and adds missing i18n keys.

Supabase queries were failing due to schema-qualified relation names (e.g., `kastle_banking.account_types`), which resulted in 400 HTTP errors. This PR removes these schema prefixes and updates the corresponding data access in the UI. Additionally, a missing `navigation.banking` i18n key was causing warnings and has been added.

---
<a href="https://cursor.com/background-agent?bcId=bc-bf603c5e-cf45-4c2e-bb25-a141e92fe70a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bf603c5e-cf45-4c2e-bb25-a141e92fe70a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

