### PR TITLE
Fix sidebar icon alignment in RTL

### DIFF
--- a/src/styles/modern-sidebar-rtl.css
+++ b/src/styles/modern-sidebar-rtl.css
@@ -1,9 +1,10 @@
 /* Modern Sidebar RTL Fixes */
 
 /* Base RTL setup for the main layout container */
-[dir="rtl"] .flex {
-  direction: ltr; /* Keep flex direction normal, use flex-row-reverse instead */
-}
+/* Removed global flex direction override to preserve natural RTL item flow */
+/* [dir="rtl"] .flex { */
+/*   direction: ltr;  Keep flex direction normal, use flex-row-reverse instead */
+/* } */
 
 /* Main layout container should use flex-row-reverse in RTL */
 [dir="rtl"] .flex.h-screen {
@@ -169,11 +170,14 @@
 }
 
 /* Ensure icons are on the right side in RTL */
+/* Disabled global order override which pushed icons after labels in RTL */
+/*
 [dir="rtl"] .gap-2 > *:first-child,
 [dir="rtl"] .gap-3 > *:first-child,
 [dir="rtl"] .gap-4 > *:first-child {
   order: 2;
 }
+*/
 
 /* Fix space between classes for RTL */
 [dir="rtl"] .space-x-2 > * + * {

--- a/src/styles/rtl.css
+++ b/src/styles/rtl.css
@@ -23,9 +23,10 @@
 }
 
 /* Flip icons in RTL */
-[dir="rtl"] .rtl-flip {
+/* Disabled global icon flip to keep icons orientation consistent in sidebar */
+/* [dir="rtl"] .rtl-flip {
   transform: scaleX(-1);
-}
+} */
 
 /* Adjust chart direction for RTL */
 [dir="rtl"] .recharts-wrapper {
@@ -200,12 +201,12 @@
 }
 
 /* Space utilities for RTL */
-[dir="rtl"] .space-x-1 > * + * {
+[dir="rtl"] .space-x-1 > *:not(:first-child) {
   margin-right: 0.25rem;
   margin-left: 0;
 }
 
-[dir="rtl"] .space-x-3 > * + * {
+[dir="rtl"] .space-x-3 > *:not(:first-child) {
   margin-right: 0.75rem;
   margin-left: 0;
 }
@@ -360,7 +361,8 @@
 }
 
 /* Fix icon positioning in buttons and labels */
-[dir="rtl"] button > .flex,
+/* Do not force icons after labels globally; components handle their own spacing */
+/* [dir="rtl"] button > .flex,
 [dir="rtl"] label > .flex {
   flex-direction: row-reverse;
 }
@@ -369,7 +371,7 @@
 [dir="rtl"] label svg:first-child {
   margin-left: 0.5rem;
   margin-right: 0;
-}
+} */
 
 /* Fix spacing utilities */
 [dir="rtl"] .space-x-1 > *:not(:first-child) {


### PR DESCRIPTION
Corrects RTL sidebar alignment by ensuring icons appear before labels, resolving issues caused by conflicting global CSS rules.

---
<a href="https://cursor.com/background-agent?bcId=bc-6909aacc-3ff4-481d-8fcf-be79257ad31e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6909aacc-3ff4-481d-8fcf-be79257ad31e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

