### PR TITLE
Initialize and handle module specifier errors

### DIFF
--- a/node_modules/.bin/autoprefixer
+++ b/node_modules/.bin/autoprefixer
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/autoprefixer" "$@"
+  exec "$basedir/node"  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
 else
-  exec node  "$basedir/../.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/autoprefixer" "$@"
+  exec node  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
 fi

--- a/node_modules/.bin/eslint
+++ b/node_modules/.bin/eslint
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/eslint.js" "$@"
+  exec "$basedir/node"  "$basedir/../eslint/bin/eslint.js" "$@"
 else
-  exec node  "$basedir/../.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/eslint.js" "$@"
+  exec node  "$basedir/../eslint/bin/eslint.js" "$@"
 fi

--- a/node_modules/.bin/tailwind
+++ b/node_modules/.bin/tailwind
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../tailwindcss/lib/cli.js" "$@"
 else
-  exec node  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
+  exec node  "$basedir/../tailwindcss/lib/cli.js" "$@"
 fi

--- a/node_modules/.bin/tailwindcss
+++ b/node_modules/.bin/tailwindcss
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../tailwindcss/lib/cli.js" "$@"
 else
-  exec node  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
+  exec node  "$basedir/../tailwindcss/lib/cli.js" "$@"
 fi

--- a/node_modules/.bin/vite
+++ b/node_modules/.bin/vite
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/vite.js" "$@"
+  exec "$basedir/node"  "$basedir/../vite/bin/vite.js" "$@"
 else
-  exec node  "$basedir/../.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/vite.js" "$@"
+  exec node  "$basedir/../vite/bin/vite.js" "$@"
 fi

--- a/vite.config.js
+++ b/vite.config.js
@@ -38,8 +38,9 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),
-        // Let jspdf and jspdf-autotable resolve via package exports
-        // no xlsx alias
+        // Prefer ESM build of jspdf for bundlers
+        "jspdf": "jspdf/dist/jspdf.es.min.js",
+        // autotable resolves via package main, no special alias needed
       },
     },
     // Explicitly define environment variables for build
@@ -67,7 +68,8 @@ export default defineConfig(({ mode }) => {
             'lucide': ['lucide-react']
           }
         },
-        external: ['jspdf', 'jspdf-autotable', 'react-pdf', 'file-saver', 'html2canvas', 'xlsx']
+        // Do not externalize libs; bundle them so bare specifiers are resolved
+        external: []
       },
       // Ensure proper handling of external dependencies
       commonjsOptions: {
@@ -75,8 +77,8 @@ export default defineConfig(({ mode }) => {
       }
     },
     optimizeDeps: {
-      include: ['lucide-react', '@hello-pangea/dnd', 'pdfjs-dist'],
-      exclude: ['xlsx', 'jspdf', 'jspdf-autotable', 'react-pdf', 'file-saver', 'html2canvas'],
+      include: ['lucide-react', '@hello-pangea/dnd', 'pdfjs-dist', 'html2canvas', 'jspdf', 'jspdf-autotable', 'file-saver', 'xlsx'],
+      exclude: [],
       // Force re-optimization in development
       force: true
     }


### PR DESCRIPTION
Bundle previously externalized libraries in Vite to resolve bare specifier errors and fix the white screen.

The application was failing to load with "bare specifier" errors for modules like `file-saver` because Vite was configured to treat them as external dependencies. This PR updates `vite.config.js` to bundle these libraries and explicitly resolves `jspdf` to its ESM build, ensuring proper module resolution and application startup.

---
<a href="https://cursor.com/background-agent?bcId=bc-962b2d32-050c-440f-a5a7-fed36e60b7a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-962b2d32-050c-440f-a5a7-fed36e60b7a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

