### PR TITLE
Initialize app and fetch dashboard data

### DIFF
--- a/public/locales/ar/translation.json
+++ b/public/locales/ar/translation.json
@@ -103,7 +103,9 @@
     "monthly": "شهري",
     "quarterly": "ربع سنوي",
     "yearly": "سنوي",
-    "na": "غير متوفر"
+    "na": "غير متوفر",
+    "current": "الحالي",
+    "target": "المستهدف"
   },
   "branches": {
     "riyadhMain": "الرياض الرئيسي",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -120,7 +120,9 @@
     "printPreview": "Print Preview",
     "printPreviewDescription": "Preview how the report will look when printed",
     "realtime": "Real-time",
-    "notConnected": "Not Connected"
+    "notConnected": "Not Connected",
+    "current": "Current",
+    "target": "Target"
   },
   "navigation": {
     "sections": {


### PR DESCRIPTION
Add missing translation keys for 'current' and 'target' to fix the Performance Radar chart not rendering on the detail page.

The radar chart's title and legend attempted to resolve `common.current` and `common.target` translation keys. When these keys were missing, it triggered parse errors from the enhanced error handler, preventing the chart from displaying even though the data was correctly fetched.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cef0797-8442-4427-bfcd-416fa3f5a80f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6cef0797-8442-4427-bfcd-416fa3f5a80f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

