### PR TITLE
Initialize and handle bare specifier errors

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -38,6 +38,7 @@ export default defineConfig(({ mode }) => {
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),
+        "jspdf": "jspdf/dist/jspdf.es.min.js"
       },
     },
     // Explicitly define environment variables for build
@@ -60,7 +61,6 @@ export default defineConfig(({ mode }) => {
     build: {
       target: 'esnext', // Support top-level await
       rollupOptions: {
-        external: ['jspdf','html2canvas','xlsx','react-pdf'],
         output: {
           manualChunks: {
             'lucide': ['lucide-react']
@@ -75,7 +75,6 @@ export default defineConfig(({ mode }) => {
     optimizeDeps: {
       include: ['lucide-react', '@hello-pangea/dnd', 'pdfjs-dist', 'html2canvas', 'jspdf', 'jspdf-autotable', 'file-saver', 'xlsx'],
       exclude: [],
-      // Force re-optimization in development
       force: true
     }
   }


### PR DESCRIPTION
Bundle previously externalized dependencies and resolve bare specifier errors.

The `html2canvas`, `jspdf`, `xlsx`, and `react-pdf` modules were marked as external in `vite.config.js`, causing them to be treated as bare specifiers in the browser and leading to runtime `TypeError`s. This change removes them from `rollupOptions.external` to ensure Vite bundles them correctly. An alias for `jspdf` was also added to point to its ESM build, resolving further build issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-f671d253-0a63-451e-adb7-066e35af5157">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f671d253-0a63-451e-adb7-066e35af5157">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

