### PR TITLE
Initialize and handle bare specifier errors

### DIFF
--- a/node_modules/.pnpm/lock.yaml
+++ b/node_modules/.pnpm/lock.yaml
@@ -122,6 +122,9 @@ importers:
       framer-motion:
         specifier: ^12.15.0
         version: 12.15.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       i18next:
         specifier: ^25.3.2
         version: 25.3.2
@@ -134,6 +137,9 @@ importers:
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      jspdf:
+        specifier: ^2.5.1
+        version: 2.5.1
       jspdf-autotable:
         specifier: ^3.8.4
         version: 3.8.4(jspdf@2.5.1)
@@ -234,12 +240,6 @@ importers:
       globals:
         specifier: ^16.0.0
         version: 16.1.0
-      html2canvas:
-        specifier: ^1.4.1
-        version: 1.4.1
-      jspdf:
-        specifier: ^2.5.1
-        version: 2.5.1
       postcss:
         specifier: ^8.5.6
         version: 8.5.6

--- a/package.json
+++ b/package.json
@@ -75,7 +75,9 @@
     "tailwind-merge": "^3.3.0",
     "vaul": "^1.1.2",
     "xlsx": "^0.18.5",
-    "zod": "^3.24.4"
+    "zod": "^3.24.4",
+    "html2canvas": "^1.4.1",
+    "jspdf": "^2.5.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
@@ -89,8 +91,6 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "glob": "^11.0.3",
     "globals": "^16.0.0",
-    "html2canvas": "^1.4.1",
-    "jspdf": "^2.5.1",
     "postcss": "^8.5.6",
     "tailwindcss": "^3.4.0",
     "tailwindcss-animate": "^1.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -122,6 +122,9 @@ importers:
       framer-motion:
         specifier: ^12.15.0
         version: 12.15.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      html2canvas:
+        specifier: ^1.4.1
+        version: 1.4.1
       i18next:
         specifier: ^25.3.2
         version: 25.3.2
@@ -134,6 +137,9 @@ importers:
       input-otp:
         specifier: ^1.4.2
         version: 1.4.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      jspdf:
+        specifier: ^2.5.1
+        version: 2.5.1
       jspdf-autotable:
         specifier: ^3.8.4
         version: 3.8.4(jspdf@2.5.1)
@@ -234,12 +240,6 @@ importers:
       globals:
         specifier: ^16.0.0
         version: 16.1.0
-      html2canvas:
-        specifier: ^1.4.1
-        version: 1.4.1
-      jspdf:
-        specifier: ^2.5.1
-        version: 2.5.1
       postcss:
         specifier: ^8.5.6
         version: 8.5.6

--- a/vite.config.js
+++ b/vite.config.js
@@ -60,7 +60,7 @@ export default defineConfig(({ mode }) => {
     build: {
       target: 'esnext', // Support top-level await
       rollupOptions: {
-        external: ['jspdf', 'jspdf-autotable', 'xlsx', 'react-pdf'],
+        external: ['jspdf', 'jspdf-autotable', 'xlsx'],
         output: {
           manualChunks: {
             'lucide': ['lucide-react']
@@ -73,7 +73,7 @@ export default defineConfig(({ mode }) => {
       }
     },
     optimizeDeps: {
-      include: ['lucide-react', '@hello-pangea/dnd', 'pdfjs-dist', 'html2canvas', 'jspdf', 'jspdf-autotable', 'file-saver', 'xlsx'],
+      include: ['lucide-react', '@hello-pangea/dnd', 'pdfjs-dist', 'html2canvas', 'jspdf', 'jspdf-autotable', 'file-saver', 'xlsx', 'react-pdf'],
       exclude: [],
       force: true
     }


### PR DESCRIPTION
Bundle `react-pdf` and move `html2canvas`/`jspdf` to dependencies to resolve bare specifier and build errors.

The initial error indicated `react-pdf` was not being resolved, likely due to it being marked as external in Vite. Moving it to `optimizeDeps.include` and removing it from `external` ensures it's bundled. Additionally, `html2canvas` and `jspdf` were in `devDependencies`, causing build failures as they are runtime dependencies. Moving them to `dependencies` allows Rollup to resolve them during the production build.

---
<a href="https://cursor.com/background-agent?bcId=bc-62517a45-cdf1-4c8f-9e95-71a573254931">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-62517a45-cdf1-4c8f-9e95-71a573254931">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

