### PR TITLE
Initialize and manage error handling

### DIFF
--- a/src/services/dashboardButtonService.js
+++ b/src/services/dashboardButtonService.js
@@ -8,6 +8,7 @@ async function getJsPDF() {
   return __JSPDF_MODULE;
 }
 // html2canvas is dynamically imported only when needed to avoid bundling issues
+// Note: dynamic import used below for html2canvas to resolve correctly under pnpm
 
 export class DashboardButtonService {
   /**
@@ -248,7 +249,7 @@ export class DashboardButtonService {
       if (!element) {
         throw new Error('Dashboard element not found');
       }
-      const { default: html2canvas } = await import('html2canvas');
+      const { default: html2canvas } = await import('html2canvas/dist/html2canvas.js');
       const canvas = await html2canvas(element, {
         allowTaint: true,
         useCORS: true,

--- a/vite.config.js
+++ b/vite.config.js
@@ -60,7 +60,7 @@ export default defineConfig(({ mode }) => {
     build: {
       target: 'esnext', // Support top-level await
       rollupOptions: {
-        external: ['jspdf', 'jspdf-autotable', 'xlsx'],
+        external: ['jspdf', 'jspdf-autotable'],
         output: {
           manualChunks: {
             'lucide': ['lucide-react']


### PR DESCRIPTION
Bundle `xlsx` to resolve bare specifier error and fix `html2canvas` import for successful production builds.

The `xlsx` library was externalized in Vite, leading to a runtime "bare specifier" error in the browser. This PR bundles `xlsx` to fix that. An unrelated build failure with `html2canvas` was also resolved by adjusting its dynamic import path.

---
<a href="https://cursor.com/background-agent?bcId=bc-47daeb4f-9978-4331-adde-d43fdbdddada">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-47daeb4f-9978-4331-adde-d43fdbdddada">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

