### PR TITLE
Adjust list item layout for RTL

### DIFF
--- a/src/components/ui/card.jsx
+++ b/src/components/ui/card.jsx
@@ -105,7 +105,6 @@ function CardFooter({
       data-slot="card-footer"
       className={cn(
         "flex items-center px-6 [.border-t]:pt-6",
-        isRTL && "flex-row-reverse",
         className
       )}
       {...props} />

--- a/src/components/ui/tabs.jsx
+++ b/src/components/ui/tabs.jsx
@@ -82,7 +82,6 @@ function TabsTrigger({
         
         // RTL support
         textAlign,
-        isRTL && "flex-row-reverse",
         
         className
       )}

--- a/src/styles/modern-sidebar-rtl.css
+++ b/src/styles/modern-sidebar-rtl.css
@@ -160,14 +160,14 @@
   }
 }
 
-/* Fix flex items inside sidebar for RTL */
-[dir="rtl"] .flex-row {
+/* Fix flex items inside sidebar for RTL - do not globally override row direction */
+/* [dir="rtl"] .flex-row {
   flex-direction: row-reverse !important;
 }
 
 [dir="rtl"] .flex-row-reverse {
   flex-direction: row !important;
-}
+} */
 
 /* Ensure icons are on the right side in RTL */
 /* Disabled global order override which pushed icons after labels in RTL */

--- a/src/styles/rtl.css
+++ b/src/styles/rtl.css
@@ -6,10 +6,10 @@
   text-align: right;
 }
 
-/* Flip layout direction for RTL */
-[dir="rtl"] .flex-row {
+/* Flip layout direction for RTL - avoid global reversal to preserve component ordering */
+/* [dir="rtl"] .flex-row {
   flex-direction: row-reverse;
-}
+} */
 
 /* Adjust spacing for RTL */
 [dir="rtl"] .space-x-2 > * + * {
@@ -459,6 +459,11 @@
 /* Ensure all flex containers in cards respect RTL */
 [dir="rtl"] .flex-row:not(.flex-row-reverse) {
   flex-direction: row-reverse;
+}
+
+/* NEW: In RTL, override explicit row-reverse to keep start at the right (icon first) */
+[dir="rtl"] .flex-row-reverse {
+  flex-direction: row !important;
 }
 
 /* Fix rounded corners for RTL */


### PR DESCRIPTION
Fixes RTL layout to display leading icons before labels by removing conflicting flex-direction overrides.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5c68ad6-db01-47ab-9cbe-17913ad4d864">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5c68ad6-db01-47ab-9cbe-17913ad4d864">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

