### PR TITLE
Initialize and manage error handling

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -60,7 +60,6 @@ export default defineConfig(({ mode }) => {
     build: {
       target: 'esnext', // Support top-level await
       rollupOptions: {
-        external: ['jspdf', 'jspdf-autotable', 'html2canvas', 'xlsx', 'react-pdf'],
         output: {
           manualChunks: {
             'lucide': ['lucide-react']


### PR DESCRIPTION
Remove externalization of `html2canvas` and related libraries in Vite config to resolve bare specifier runtime errors.

The previous configuration marked `html2canvas`, `jspdf`, `xlsx`, and `react-pdf` as external, causing the browser to encounter bare module specifiers at runtime. This change ensures these libraries are bundled by Vite, resolving the `Uncaught TypeError: The specifier “html2canvas” was a bare specifier, but was not remapped to anything` error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4f78067-e491-4755-b741-ec3575291766">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d4f78067-e491-4755-b741-ec3575291766">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

