### PR TITLE
Build project with json syntax error

### DIFF
--- a/public/locales/ar/translation.json
+++ b/public/locales/ar/translation.json
@@ -3429,9 +3429,8 @@
      "marketShare": "الحصة السوقية",
      "profitability": "الربحية",
      "risk": "المخاطر",
-     "satisfaction": "رضا العملاء",
-     "riskScore": "درجة المخاطر",
-     "customerSatisfaction": "رضا العملاء"
-   }
-  }
-}
+           "satisfaction": "رضا العملاء",
+      "riskScore": "درجة المخاطر",
+      "customerSatisfaction": "رضا العملاء"
+    }
+ }

--- a/vite.config.js
+++ b/vite.config.js
@@ -37,7 +37,7 @@ export default defineConfig(({ mode }) => {
     ],
     resolve: {
       alias: {
-        "@": path.resolve(__dirname, "./src"),
+        "@": path.resolve(__dirname, "./src")
       },
     },
     // Explicitly define environment variables for build
@@ -64,7 +64,9 @@ export default defineConfig(({ mode }) => {
           manualChunks: {
             'lucide': ['lucide-react']
           }
-        }
+        },
+        // Avoid bundling jspdf which we load dynamically at runtime
+        external: ['jspdf']
       },
       // Ensure proper handling of external dependencies
       commonjsOptions: {
@@ -72,8 +74,8 @@ export default defineConfig(({ mode }) => {
       }
     },
     optimizeDeps: {
-      include: ['lucide-react', '@hello-pangea/dnd', 'pdfjs-dist', 'html2canvas', 'jspdf', 'jspdf-autotable', 'file-saver', 'xlsx', 'react-pdf'],
-      exclude: [],
+      include: ['lucide-react', '@hello-pangea/dnd', 'pdfjs-dist', 'html2canvas', 'file-saver', 'xlsx', 'react-pdf'],
+      exclude: ['jspdf'],
       force: true
     }
   }


### PR DESCRIPTION
Fixes JSON syntax error in translation file and externalizes `jspdf` to resolve build failures.

The build initially failed due to a malformed JSON file. After correcting the JSON, a new build error related to `jspdf` occurred, which was resolved by configuring Vite to treat `jspdf` as an external dependency, preventing it from being bundled.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c79ae94-8866-46f8-ae97-8eff310964c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c79ae94-8866-46f8-ae97-8eff310964c1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

