### PR TITLE
Initialize dashboard and fix missing column

### DIFF
--- a/node_modules/.bin/autoprefixer
+++ b/node_modules/.bin/autoprefixer
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/node_modules:/workspace/node_modules/.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/autoprefixer" "$@"
 else
-  exec node  "$basedir/../autoprefixer/bin/autoprefixer" "$@"
+  exec node  "$basedir/../.pnpm/autoprefixer@10.4.21_postcss@8.5.6/node_modules/autoprefixer/bin/autoprefixer" "$@"
 fi

--- a/node_modules/.bin/eslint
+++ b/node_modules/.bin/eslint
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/node_modules:/workspace/node_modules/.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../eslint/bin/eslint.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/eslint.js" "$@"
 else
-  exec node  "$basedir/../eslint/bin/eslint.js" "$@"
+  exec node  "$basedir/../.pnpm/eslint@9.26.0_jiti@2.4.2/node_modules/eslint/bin/eslint.js" "$@"
 fi

--- a/node_modules/.bin/tailwind
+++ b/node_modules/.bin/tailwind
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 else
-  exec node  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec node  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 fi

--- a/node_modules/.bin/tailwindcss
+++ b/node_modules/.bin/tailwindcss
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/node_modules:/workspace/node_modules/.pnpm/tailwindcss@3.4.17/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 else
-  exec node  "$basedir/../tailwindcss/lib/cli.js" "$@"
+  exec node  "$basedir/../.pnpm/tailwindcss@3.4.17/node_modules/tailwindcss/lib/cli.js" "$@"
 fi

--- a/node_modules/.bin/vite
+++ b/node_modules/.bin/vite
@@ -11,7 +11,7 @@ else
   export NODE_PATH="/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/node_modules:/workspace/node_modules/.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules:/workspace/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
-  exec "$basedir/node"  "$basedir/../vite/bin/vite.js" "$@"
+  exec "$basedir/node"  "$basedir/../.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/vite.js" "$@"
 else
-  exec node  "$basedir/../vite/bin/vite.js" "$@"
+  exec node  "$basedir/../.pnpm/vite@6.3.5_@types+node@24.1.0_jiti@2.4.2_lightningcss@1.30.1_yaml@2.8.0/node_modules/vite/bin/vite.js" "$@"
 fi

--- a/src/pages/ExecutiveDashboardComprehensive.tsx
+++ b/src/pages/ExecutiveDashboardComprehensive.tsx
@@ -168,7 +168,7 @@ const ExecutiveDashboardComprehensive = () => {
           branch_name,
           branch_code,
           city,
-          region,
+          region:state,
           is_active
         `)
         .eq('is_active', true);


### PR DESCRIPTION
Alias `branches.state` as `region` in the Executive Dashboard query to resolve a "column does not exist" error.

The database schema for the `branches` table uses `state` for regional information, but the frontend query in `ExecutiveDashboardComprehensive.tsx` was attempting to select a `region` column directly. This PR aligns the query with the existing schema by aliasing `state` to `region`, preventing the `column branches.region does not exist` error without requiring a database migration.

---
<a href="https://cursor.com/background-agent?bcId=bc-d102eef2-8d73-4459-a862-9cdeefe97050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d102eef2-8d73-4459-a862-9cdeefe97050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

