### PR TITLE
Initialize application and fetch dashboard data

### DIFF
--- a/src/lib/supabase.js
+++ b/src/lib/supabase.js
@@ -228,46 +228,8 @@ export const supabase = (() => {
 // Create a client specifically for kastle_banking schema
 export const supabaseBanking = (() => {
   if (!supabaseBankingInstance) {
-            supabaseBankingInstance = isSupabaseConfigured
-          ? createClient(supabaseUrl, supabaseAnonKey, {
-              db: {
-                schema: 'kastle_banking'
-              },
-              auth: {
-                autoRefreshToken: true,
-                persistSession: true,
-                detectSessionInUrl: true,
-                storage: window.localStorage,
-                storageKey: 'osol-auth-banking',
-                // Disable cookie-based auth to prevent domain issues
-                flowType: 'implicit',
-                // Ensure cookies are not used for auth
-                cookieOptions: {
-                  domain: '',
-                  path: '/',
-                  sameSite: 'lax',
-                  secure: false
-                }
-              },
-          realtime: {
-            params: {
-              eventsPerSecond: 10
-            },
-            headers: {
-              'X-Client-Info': 'supabase-js-web'
-            }
-          },
-          global: {
-            headers: {
-              'apikey': supabaseAnonKey,
-              // Removed global 'Prefer' header to allow per-request count and head options from supabase-js
-              'Accept-Profile': 'kastle_banking',
-              'Content-Profile': 'kastle_banking'
-            },
-            fetch: customFetch
-          }
-        })
-      : createMockClient();
+    // Reuse the singleton supabase instance to avoid multiple GoTrueClient instances
+    supabaseBankingInstance = supabase;
   }
   return supabaseBankingInstance;
 })();

--- a/src/pages/ExecutiveDashboardComprehensive.tsx
+++ b/src/pages/ExecutiveDashboardComprehensive.tsx
@@ -175,7 +175,19 @@ const ExecutiveDashboardComprehensive = () => {
 
       if (branchesError) throw branchesError;
 
-      // Fetch products data
+      // Fetch product categories separately to avoid implicit relationship requirement
+      const { data: categoriesData, error: categoriesError } = await supabaseBanking
+        .from('product_categories')
+        .select('category_id, category_name, name, name_ar');
+
+      if (categoriesError) throw categoriesError;
+
+      // Build a map of category_id -> category display name
+      const categoryNameById = Object.fromEntries(
+        (categoriesData || []).map(c => [c.category_id, c.category_name || c.name || 'Uncategorized'])
+      );
+
+      // Fetch products data (without nested relationship)
       const { data: productsData, error: productsError } = await supabaseBanking
         .from('products')
         .select(`
@@ -183,11 +195,7 @@ const ExecutiveDashboardComprehensive = () => {
           product_name,
           product_code,
           category_id,
-          is_active,
-          product_categories (
-            name,
-            name_ar
-          )
+          is_active
         `)
         .eq('is_active', true);
 
@@ -288,7 +296,7 @@ const ExecutiveDashboardComprehensive = () => {
           id: product.product_id,
           name: product.product_name,
           nameAr: product.product_name,
-          category: product.product_categories?.name || 'Uncategorized',
+          category: categoryNameById[product.category_id] || 'Uncategorized',
           metrics: {
             activeAccounts,
             revenue,


### PR DESCRIPTION
Resolves PostgREST relationship error and multiple Supabase client warning by refactoring data fetching and client instantiation.

The `PGRST200` error was caused by an implicit PostgREST join between `products` and `product_categories` that was not supported by the schema. This is now resolved by fetching product categories separately and mapping them in the application. The "Multiple GoTrueClient instances" warning is eliminated by ensuring `supabaseBanking` reuses the main `supabase` singleton instance.

---
<a href="https://cursor.com/background-agent?bcId=bc-99473772-cb46-4c50-93b0-fe0987b97063">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99473772-cb46-4c50-93b0-fe0987b97063">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

