### PR TITLE
Fix osol_full_schema.sq errors and missing keys

### DIFF
--- a/public/locales/ar/translation.json
+++ b/public/locales/ar/translation.json
@@ -3458,5 +3458,11 @@
            "satisfaction": "رضا العملاء",
       "riskScore": "درجة المخاطر",
       "customerSatisfaction": "رضا العملاء"
+    },
+    "details": {
+      "totalDueAmountTitle": "تفاصيل إجمالي المبالغ المستحقة",
+      "totalDueAmountSubtitle": "عرض شامل لجميع المبالغ المستحقة",
+      "nonDueAmountTitle": "تفاصيل المبالغ غير المستحقة",
+      "overdueAmountTitle": "تفاصيل المبالغ المتأخرة"
     }
- }
+  }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -3450,5 +3450,11 @@
     "satisfaction": "Customer Satisfaction",
     "riskScore": "Risk Score",
     "customerSatisfaction": "Customer Satisfaction"
+  },
+  "details": {
+    "totalDueAmountTitle": "Total Due Amount Details",
+    "totalDueAmountSubtitle": "Comprehensive view of all due amounts",
+    "nonDueAmountTitle": "Non-Due Amount Details",
+    "overdueAmountTitle": "Overdue Amount Details"
   }
 }

--- a/src/pages/details/DueAmountDetail.jsx
+++ b/src/pages/details/DueAmountDetail.jsx
@@ -73,7 +73,7 @@ export default function DueAmountDetail() {
             customer_id,
             first_name,
             last_name,
-            phone,
+            mobile_number,
             email
           )
         `)
@@ -331,10 +331,10 @@ export default function DueAmountDetail() {
           <div>
             <h1 className="text-2xl font-bold flex items-center gap-2">
               <AlertCircle className="h-6 w-6 text-yellow-600" />
-              {t('Total Due Amount Details', 'Total Due Amount Details')}
+              {t('details.totalDueAmountTitle', 'Total Due Amount Details')}
             </h1>
             <p className="text-muted-foreground">
-              {t('Comprehensive view of all due amounts', 'Comprehensive view of all due amounts')}
+              {t('details.totalDueAmountSubtitle', 'Comprehensive view of all due amounts')}
             </p>
           </div>
         </div>
@@ -346,7 +346,7 @@ export default function DueAmountDetail() {
             disabled={refreshing}
           >
             <RefreshCw className={cn("h-4 w-4", refreshing && "animate-spin", isRTL ? "ml-2" : "mr-2")} />
-            {t('Refresh', 'Refresh')}
+            {t('common.refresh', 'Refresh')}
           </Button>
           <Button
             variant="outline"
@@ -354,7 +354,7 @@ export default function DueAmountDetail() {
             onClick={handleExport}
           >
             <Download className={cn("h-4 w-4", isRTL ? "ml-2" : "mr-2")} />
-            {t('Export', 'Export')}
+            {t('common.export', 'Export')}
           </Button>
         </div>
       </div>

--- a/src/pages/details/NonDueAmountDetail.jsx
+++ b/src/pages/details/NonDueAmountDetail.jsx
@@ -75,9 +75,8 @@ export default function NonDueAmountDetail() {
             customer_id,
             first_name,
             last_name,
-            phone,
-            email,
-            credit_score
+            mobile_number,
+            email
           )
         `)
         .eq('loan_status', 'ACTIVE')
@@ -379,7 +378,7 @@ export default function NonDueAmountDetail() {
           <div>
             <h1 className="text-2xl font-bold flex items-center gap-2">
               <CheckCircle className="h-6 w-6 text-green-600" />
-              {t('Non-Due Amount Details', 'Non-Due Amount Details')}
+              {t('details.nonDueAmountTitle', 'Non-Due Amount Details')}
             </h1>
             <p className="text-muted-foreground">
               {t('Analysis of performing loans with no overdue', 'Analysis of performing loans with no overdue')}
@@ -394,7 +393,7 @@ export default function NonDueAmountDetail() {
             disabled={refreshing}
           >
             <RefreshCw className={cn("h-4 w-4", refreshing && "animate-spin", isRTL ? "ml-2" : "mr-2")} />
-            {t('Refresh', 'Refresh')}
+            {t('common.refresh', 'Refresh')}
           </Button>
           <Button
             variant="outline"
@@ -402,7 +401,7 @@ export default function NonDueAmountDetail() {
             onClick={handleExport}
           >
             <Download className={cn("h-4 w-4", isRTL ? "ml-2" : "mr-2")} />
-            {t('Export', 'Export')}
+            {t('common.export', 'Export')}
           </Button>
         </div>
       </div>

--- a/src/pages/details/OverdueAmountDetail.jsx
+++ b/src/pages/details/OverdueAmountDetail.jsx
@@ -78,9 +78,8 @@ export default function OverdueAmountDetail() {
             customer_id,
             first_name,
             last_name,
-            phone,
-            email,
-            credit_score
+            mobile_number,
+            email
           )
         `)
         .gt('overdue_days', 0)
@@ -466,7 +465,7 @@ export default function OverdueAmountDetail() {
           <div>
             <h1 className="text-2xl font-bold flex items-center gap-2">
               <AlertTriangle className="h-6 w-6 text-red-600" />
-              {t('Overdue Amount Details', 'Overdue Amount Details')}
+              {t('details.overdueAmountTitle', 'Overdue Amount Details')}
             </h1>
             <p className="text-muted-foreground">
               {t('Analysis of delinquent loans and collection priorities', 'Analysis of delinquent loans and collection priorities')}
@@ -481,7 +480,7 @@ export default function OverdueAmountDetail() {
             disabled={refreshing}
           >
             <RefreshCw className={cn("h-4 w-4", refreshing && "animate-spin", isRTL ? "ml-2" : "mr-2")} />
-            {t('Refresh', 'Refresh')}
+            {t('common.refresh', 'Refresh')}
           </Button>
           <Button
             variant="outline"
@@ -489,7 +488,7 @@ export default function OverdueAmountDetail() {
             onClick={handleExport}
           >
             <Download className={cn("h-4 w-4", isRTL ? "ml-2" : "mr-2")} />
-            {t('Export', 'Export')}
+            {t('common.export', 'Export')}
           </Button>
         </div>
       </div>
@@ -816,7 +815,7 @@ export default function OverdueAmountDetail() {
                         </TableCell>
                         <TableCell>
                           <div className="space-y-1">
-                            {item.customers?.phone && (
+                            {item.customers?.mobile_number && (
                               <Button variant="ghost" size="sm" className="h-6 px-2">
                                 <Phone className="h-3 w-3 mr-1" />
                                 Call


### PR DESCRIPTION
Aligns Supabase queries with the database schema and resolves translation warnings to fix 400 errors on due amount pages.

The 400 errors occurred because Supabase queries for `loan_accounts` were attempting to select non-existent `phone` and `credit_score` columns from the joined `customers` table. This PR updates the queries to use `mobile_number` (the correct column) and removes the `credit_score` selection. It also addresses "Parse missing key" warnings by updating translation key references and adding new keys for detail page titles.

---
<a href="https://cursor.com/background-agent?bcId=bc-263bba44-b53f-46ec-9d4c-455705990ea4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-263bba44-b53f-46ec-9d4c-455705990ea4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

