### PR TITLE
Build sales and collection comparison dashboard

### DIFF
--- a/run_comparison_setup.sh
+++ b/run_comparison_setup.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Apply comparison dashboard SQL using Supabase RPC exec_sql
+# Requires: VITE_SUPABASE_URL and VITE_SUPABASE_SERVICE_ROLE_KEY in .env
+
+if [ -f .env ]; then
+  source .env
+fi
+
+if [ -z "${VITE_SUPABASE_URL:-}" ] || [ -z "${VITE_SUPABASE_SERVICE_ROLE_KEY:-}" ]; then
+  echo "Missing VITE_SUPABASE_URL or VITE_SUPABASE_SERVICE_ROLE_KEY. Please set them in .env"
+  exit 1
+fi
+
+SQL_FILE="/workspace/setup_comparison_dashboard.sql"
+if [ ! -f "$SQL_FILE" ]; then
+  echo "SQL file not found: $SQL_FILE"
+  exit 1
+fi
+
+payload=$(jq -Rs . < "$SQL_FILE")
+
+curl -s -X POST \
+  "$VITE_SUPABASE_URL/rest/v1/rpc/exec_sql" \
+  -H "apikey: $VITE_SUPABASE_SERVICE_ROLE_KEY" \
+  -H "Authorization: Bearer $VITE_SUPABASE_SERVICE_ROLE_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"query\": $payload}" | cat
+
+echo "\nDone."

--- a/setup_comparison_dashboard.sql
+++ b/setup_comparison_dashboard.sql
@@ -1,0 +1,515 @@
+-- Schema: kastle_banking
+-- Purpose: Comparison dashboard base views and helper functions
+
+-- Note: This script creates lightweight daily views per domain and
+-- comparison functions that aggregate by day/month/quarter/year.
+-- It relies only on existing tables found in osol_full_schema.sql.
+
+-- =========================
+-- Sales (Transactions) Daily View
+-- =========================
+DROP VIEW IF EXISTS kastle_banking.vw_sales_daily CASCADE;
+CREATE VIEW kastle_banking.vw_sales_daily AS
+WITH tx AS (
+  SELECT 
+    t.transaction_date::date AS metric_date,
+    COALESCE(t.branch_id, a.branch_id) AS branch_id,
+    a.product_id,
+    t.debit_credit,
+    t.status,
+    t.transaction_amount::numeric(18,2) AS amount
+  FROM kastle_banking.transactions t
+  LEFT JOIN kastle_banking.accounts a
+    ON a.account_number::text = t.account_number::text
+)
+SELECT 
+  metric_date,
+  branch_id,
+  product_id,
+  SUM(CASE WHEN debit_credit = 'CREDIT' AND status = 'COMPLETED' THEN amount ELSE 0 END) AS sales_amount,
+  COUNT(*) FILTER (WHERE debit_credit = 'CREDIT' AND status = 'COMPLETED') AS sales_count
+FROM tx
+GROUP BY metric_date, branch_id, product_id;
+
+-- Index recommendation (optional, not created here):
+-- CREATE INDEX ON kastle_banking.transactions (transaction_date, branch_id);
+-- CREATE INDEX ON kastle_banking.accounts (account_number, product_id, branch_id);
+
+-- =========================
+-- Collections Daily View (from daily_collection_summary)
+-- =========================
+DROP VIEW IF EXISTS kastle_banking.vw_collections_daily CASCADE;
+CREATE VIEW kastle_banking.vw_collections_daily AS
+SELECT 
+  d.summary_date AS metric_date,
+  d.branch_id,
+  NULL::integer AS product_id, -- Not product-specific in current schema
+  d.total_due_amount,
+  d.total_collected,
+  d.collection_rate,
+  d.accounts_due,
+  d.accounts_collected,
+  d.ptps_obtained,
+  d.ptps_kept,
+  d.digital_payments
+FROM kastle_banking.daily_collection_summary d;
+
+-- =========================
+-- Customers Daily View
+-- =========================
+DROP VIEW IF EXISTS kastle_banking.vw_customers_daily CASCADE;
+CREATE VIEW kastle_banking.vw_customers_daily AS
+SELECT 
+  c.onboarding_date AS metric_date,
+  COALESCE(c.onboarding_branch, NULLIF(c.branch_id, '')::varchar(10)) AS branch_id,
+  COUNT(*) AS new_customers
+FROM kastle_banking.customers c
+WHERE c.onboarding_date IS NOT NULL
+GROUP BY c.onboarding_date, COALESCE(c.onboarding_branch, NULLIF(c.branch_id, '')::varchar(10));
+
+-- =========================
+-- Accounts (Products) Daily View
+-- =========================
+DROP VIEW IF EXISTS kastle_banking.vw_accounts_daily CASCADE;
+CREATE VIEW kastle_banking.vw_accounts_daily AS
+SELECT 
+  a.opening_date AS metric_date,
+  a.branch_id,
+  a.product_id,
+  COUNT(*) AS new_accounts
+FROM kastle_banking.accounts a
+WHERE a.opening_date IS NOT NULL
+GROUP BY a.opening_date, a.branch_id, a.product_id;
+
+-- =========================
+-- Collection Cases Daily View
+-- =========================
+DROP VIEW IF EXISTS kastle_banking.vw_cases_daily CASCADE;
+CREATE VIEW kastle_banking.vw_cases_daily AS
+WITH created_cases AS (
+  SELECT 
+    cc.created_at::date AS metric_date,
+    cc.branch_id,
+    cc.product_type,
+    COUNT(*) AS new_cases
+  FROM kastle_banking.collection_cases cc
+  WHERE cc.created_at IS NOT NULL
+  GROUP BY cc.created_at::date, cc.branch_id, cc.product_type
+),
+resolved_cases AS (
+  SELECT 
+    cc.updated_at::date AS metric_date,
+    cc.branch_id,
+    cc.product_type,
+    COUNT(*) AS resolved_cases
+  FROM kastle_banking.collection_cases cc
+  WHERE cc.updated_at IS NOT NULL
+    AND cc.case_status IN ('RESOLVED','CLOSED','SETTLED','WRITTEN_OFF')
+  GROUP BY cc.updated_at::date, cc.branch_id, cc.product_type
+)
+SELECT 
+  COALESCE(cr.metric_date, rs.metric_date) AS metric_date,
+  COALESCE(cr.branch_id, rs.branch_id) AS branch_id,
+  COALESCE(cr.product_type, rs.product_type) AS product_type,
+  COALESCE(cr.new_cases, 0) AS new_cases,
+  COALESCE(rs.resolved_cases, 0) AS resolved_cases
+FROM created_cases cr
+FULL OUTER JOIN resolved_cases rs
+  ON cr.metric_date = rs.metric_date
+ AND cr.branch_id = rs.branch_id
+ AND COALESCE(cr.product_type, '') = COALESCE(rs.product_type, '');
+
+-- =========================
+-- Helper: period_bucket function (day/month/quarter/year)
+-- =========================
+DROP FUNCTION IF EXISTS kastle_banking.period_bucket(date, text) CASCADE;
+CREATE FUNCTION kastle_banking.period_bucket(p_date date, p_granularity text)
+RETURNS date
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT CASE 
+    WHEN lower(p_granularity) = 'day' THEN p_date
+    WHEN lower(p_granularity) = 'month' THEN date_trunc('month', p_date)::date
+    WHEN lower(p_granularity) = 'quarter' THEN date_trunc('quarter', p_date)::date
+    WHEN lower(p_granularity) = 'year' THEN date_trunc('year', p_date)::date
+    ELSE p_date
+  END;
+$$;
+
+-- =========================
+-- Generic comparison helper to compute delta and pct change
+-- =========================
+DROP FUNCTION IF EXISTS kastle_banking.compute_change(numeric, numeric) CASCADE;
+CREATE FUNCTION kastle_banking.compute_change(v2 numeric, v1 numeric)
+RETURNS TABLE(delta numeric, pct_change numeric)
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT 
+    (v2 - v1) AS delta,
+    CASE WHEN v1 IS NULL OR v1 = 0 THEN NULL ELSE ((v2 - v1) / v1) * 100 END AS pct_change;
+$$;
+
+-- =========================
+-- Comparison functions per domain
+-- =========================
+-- Each function returns aggregated values for two arbitrary date ranges
+-- and supports optional filtering by branch and product (where applicable).
+
+-- 1) Sales comparison
+DROP FUNCTION IF EXISTS kastle_banking.fn_compare_sales(text[], integer[], date, date, date, date, text) CASCADE;
+CREATE FUNCTION kastle_banking.fn_compare_sales(
+  p_branch_ids text[] DEFAULT NULL,
+  p_product_ids integer[] DEFAULT NULL,
+  p_start_1 date,
+  p_end_1 date,
+  p_start_2 date,
+  p_end_2 date,
+  p_granularity text DEFAULT 'month'
+)
+RETURNS TABLE (
+  period date,
+  branch_id varchar(10),
+  product_id integer,
+  value_1 numeric,
+  value_2 numeric,
+  delta numeric,
+  pct_change numeric
+)
+LANGUAGE sql
+AS $$
+WITH d1 AS (
+  SELECT period_bucket(metric_date, p_granularity) AS period,
+         branch_id,
+         product_id,
+         SUM(sales_amount) AS value
+  FROM kastle_banking.vw_sales_daily
+  WHERE metric_date BETWEEN p_start_1 AND p_end_1
+    AND (p_branch_ids IS NULL OR branch_id = ANY(p_branch_ids))
+    AND (p_product_ids IS NULL OR product_id = ANY(p_product_ids))
+  GROUP BY 1,2,3
+), d2 AS (
+  SELECT period_bucket(metric_date, p_granularity) AS period,
+         branch_id,
+         product_id,
+         SUM(sales_amount) AS value
+  FROM kastle_banking.vw_sales_daily
+  WHERE metric_date BETWEEN p_start_2 AND p_end_2
+    AND (p_branch_ids IS NULL OR branch_id = ANY(p_branch_ids))
+    AND (p_product_ids IS NULL OR product_id = ANY(p_product_ids))
+  GROUP BY 1,2,3
+)
+SELECT 
+  COALESCE(d1.period, d2.period) AS period,
+  COALESCE(d1.branch_id, d2.branch_id) AS branch_id,
+  COALESCE(d1.product_id, d2.product_id) AS product_id,
+  COALESCE(d1.value, 0) AS value_1,
+  COALESCE(d2.value, 0) AS value_2,
+  (SELECT delta FROM kastle_banking.compute_change(COALESCE(d2.value,0), COALESCE(d1.value,0))) AS delta,
+  (SELECT pct_change FROM kastle_banking.compute_change(COALESCE(d2.value,0), COALESCE(d1.value,0))) AS pct_change
+FROM d1
+FULL OUTER JOIN d2 USING (period, branch_id, product_id)
+ORDER BY period, branch_id, product_id;
+$$;
+
+-- 2) Collections comparison
+DROP FUNCTION IF EXISTS kastle_banking.fn_compare_collections(text[], date, date, date, date, text) CASCADE;
+CREATE FUNCTION kastle_banking.fn_compare_collections(
+  p_branch_ids text[] DEFAULT NULL,
+  p_start_1 date,
+  p_end_1 date,
+  p_start_2 date,
+  p_end_2 date,
+  p_granularity text DEFAULT 'month'
+)
+RETURNS TABLE (
+  period date,
+  branch_id varchar(10),
+  value_1 numeric,
+  value_2 numeric,
+  delta numeric,
+  pct_change numeric
+)
+LANGUAGE sql
+AS $$
+WITH d1 AS (
+  SELECT period_bucket(metric_date, p_granularity) AS period,
+         branch_id,
+         SUM(total_collected) AS value
+  FROM kastle_banking.vw_collections_daily
+  WHERE metric_date BETWEEN p_start_1 AND p_end_1
+    AND (p_branch_ids IS NULL OR branch_id = ANY(p_branch_ids))
+  GROUP BY 1,2
+), d2 AS (
+  SELECT period_bucket(metric_date, p_granularity) AS period,
+         branch_id,
+         SUM(total_collected) AS value
+  FROM kastle_banking.vw_collections_daily
+  WHERE metric_date BETWEEN p_start_2 AND p_end_2
+    AND (p_branch_ids IS NULL OR branch_id = ANY(p_branch_ids))
+  GROUP BY 1,2
+)
+SELECT 
+  COALESCE(d1.period, d2.period) AS period,
+  COALESCE(d1.branch_id, d2.branch_id) AS branch_id,
+  COALESCE(d1.value, 0) AS value_1,
+  COALESCE(d2.value, 0) AS value_2,
+  (SELECT delta FROM kastle_banking.compute_change(COALESCE(d2.value,0), COALESCE(d1.value,0))) AS delta,
+  (SELECT pct_change FROM kastle_banking.compute_change(COALESCE(d2.value,0), COALESCE(d1.value,0))) AS pct_change
+FROM d1
+FULL OUTER JOIN d2 USING (period, branch_id)
+ORDER BY period, branch_id;
+$$;
+
+-- 3) Customers comparison (new customers)
+DROP FUNCTION IF EXISTS kastle_banking.fn_compare_customers(text[], date, date, date, date, text) CASCADE;
+CREATE FUNCTION kastle_banking.fn_compare_customers(
+  p_branch_ids text[] DEFAULT NULL,
+  p_start_1 date,
+  p_end_1 date,
+  p_start_2 date,
+  p_end_2 date,
+  p_granularity text DEFAULT 'month'
+)
+RETURNS TABLE (
+  period date,
+  branch_id varchar(10),
+  value_1 bigint,
+  value_2 bigint,
+  delta bigint,
+  pct_change numeric
+)
+LANGUAGE sql
+AS $$
+WITH d1 AS (
+  SELECT period_bucket(metric_date, p_granularity) AS period,
+         branch_id,
+         SUM(new_customers)::bigint AS value
+  FROM kastle_banking.vw_customers_daily
+  WHERE metric_date BETWEEN p_start_1 AND p_end_1
+    AND (p_branch_ids IS NULL OR branch_id = ANY(p_branch_ids))
+  GROUP BY 1,2
+), d2 AS (
+  SELECT period_bucket(metric_date, p_granularity) AS period,
+         branch_id,
+         SUM(new_customers)::bigint AS value
+  FROM kastle_banking.vw_customers_daily
+  WHERE metric_date BETWEEN p_start_2 AND p_end_2
+    AND (p_branch_ids IS NULL OR branch_id = ANY(p_branch_ids))
+  GROUP BY 1,2
+)
+SELECT 
+  COALESCE(d1.period, d2.period) AS period,
+  COALESCE(d1.branch_id, d2.branch_id) AS branch_id,
+  COALESCE(d1.value, 0) AS value_1,
+  COALESCE(d2.value, 0) AS value_2,
+  (COALESCE(d2.value,0) - COALESCE(d1.value,0)) AS delta,
+  CASE WHEN COALESCE(d1.value,0) = 0 THEN NULL ELSE ((COALESCE(d2.value,0) - COALESCE(d1.value,0))::numeric / COALESCE(d1.value,0)) * 100 END AS pct_change
+FROM d1
+FULL OUTER JOIN d2 USING (period, branch_id)
+ORDER BY period, branch_id;
+$$;
+
+-- 4) Accounts (Products) comparison (new accounts)
+DROP FUNCTION IF EXISTS kastle_banking.fn_compare_accounts(text[], integer[], date, date, date, date, text) CASCADE;
+CREATE FUNCTION kastle_banking.fn_compare_accounts(
+  p_branch_ids text[] DEFAULT NULL,
+  p_product_ids integer[] DEFAULT NULL,
+  p_start_1 date,
+  p_end_1 date,
+  p_start_2 date,
+  p_end_2 date,
+  p_granularity text DEFAULT 'month'
+)
+RETURNS TABLE (
+  period date,
+  branch_id varchar(10),
+  product_id integer,
+  value_1 bigint,
+  value_2 bigint,
+  delta bigint,
+  pct_change numeric
+)
+LANGUAGE sql
+AS $$
+WITH d1 AS (
+  SELECT period_bucket(metric_date, p_granularity) AS period,
+         branch_id,
+         product_id,
+         SUM(new_accounts)::bigint AS value
+  FROM kastle_banking.vw_accounts_daily
+  WHERE metric_date BETWEEN p_start_1 AND p_end_1
+    AND (p_branch_ids IS NULL OR branch_id = ANY(p_branch_ids))
+    AND (p_product_ids IS NULL OR product_id = ANY(p_product_ids))
+  GROUP BY 1,2,3
+), d2 AS (
+  SELECT period_bucket(metric_date, p_granularity) AS period,
+         branch_id,
+         product_id,
+         SUM(new_accounts)::bigint AS value
+  FROM kastle_banking.vw_accounts_daily
+  WHERE metric_date BETWEEN p_start_2 AND p_end_2
+    AND (p_branch_ids IS NULL OR branch_id = ANY(p_branch_ids))
+    AND (p_product_ids IS NULL OR product_id = ANY(p_product_ids))
+  GROUP BY 1,2,3
+)
+SELECT 
+  COALESCE(d1.period, d2.period) AS period,
+  COALESCE(d1.branch_id, d2.branch_id) AS branch_id,
+  COALESCE(d1.product_id, d2.product_id) AS product_id,
+  COALESCE(d1.value, 0) AS value_1,
+  COALESCE(d2.value, 0) AS value_2,
+  (COALESCE(d2.value,0) - COALESCE(d1.value,0)) AS delta,
+  CASE WHEN COALESCE(d1.value,0) = 0 THEN NULL ELSE ((COALESCE(d2.value,0) - COALESCE(d1.value,0))::numeric / COALESCE(d1.value,0)) * 100 END AS pct_change
+FROM d1
+FULL OUTER JOIN d2 USING (period, branch_id, product_id)
+ORDER BY period, branch_id, product_id;
+$$;
+
+-- 5) Cases comparison (by product_type text)
+DROP FUNCTION IF EXISTS kastle_banking.fn_compare_cases(text[], text[], date, date, date, date, text) CASCADE;
+CREATE FUNCTION kastle_banking.fn_compare_cases(
+  p_branch_ids text[] DEFAULT NULL,
+  p_product_types text[] DEFAULT NULL,
+  p_start_1 date,
+  p_end_1 date,
+  p_start_2 date,
+  p_end_2 date,
+  p_granularity text DEFAULT 'month'
+)
+RETURNS TABLE (
+  period date,
+  branch_id varchar(10),
+  product_type text,
+  new_cases_1 bigint,
+  new_cases_2 bigint,
+  new_cases_delta bigint,
+  new_cases_pct_change numeric,
+  resolved_cases_1 bigint,
+  resolved_cases_2 bigint,
+  resolved_cases_delta bigint,
+  resolved_cases_pct_change numeric
+)
+LANGUAGE sql
+AS $$
+WITH d1 AS (
+  SELECT period_bucket(metric_date, p_granularity) AS period,
+         branch_id,
+         product_type,
+         SUM(new_cases)::bigint AS new_cases,
+         SUM(resolved_cases)::bigint AS resolved_cases
+  FROM kastle_banking.vw_cases_daily
+  WHERE metric_date BETWEEN p_start_1 AND p_end_1
+    AND (p_branch_ids IS NULL OR branch_id = ANY(p_branch_ids))
+    AND (p_product_types IS NULL OR product_type = ANY(p_product_types))
+  GROUP BY 1,2,3
+), d2 AS (
+  SELECT period_bucket(metric_date, p_granularity) AS period,
+         branch_id,
+         product_type,
+         SUM(new_cases)::bigint AS new_cases,
+         SUM(resolved_cases)::bigint AS resolved_cases
+  FROM kastle_banking.vw_cases_daily
+  WHERE metric_date BETWEEN p_start_2 AND p_end_2
+    AND (p_branch_ids IS NULL OR branch_id = ANY(p_branch_ids))
+    AND (p_product_types IS NULL OR product_type = ANY(p_product_types))
+  GROUP BY 1,2,3
+)
+SELECT 
+  COALESCE(d1.period, d2.period) AS period,
+  COALESCE(d1.branch_id, d2.branch_id) AS branch_id,
+  COALESCE(d1.product_type, d2.product_type) AS product_type,
+  COALESCE(d1.new_cases, 0) AS new_cases_1,
+  COALESCE(d2.new_cases, 0) AS new_cases_2,
+  (COALESCE(d2.new_cases,0) - COALESCE(d1.new_cases,0)) AS new_cases_delta,
+  CASE WHEN COALESCE(d1.new_cases,0) = 0 THEN NULL ELSE ((COALESCE(d2.new_cases,0) - COALESCE(d1.new_cases,0))::numeric / COALESCE(d1.new_cases,0)) * 100 END AS new_cases_pct_change,
+  COALESCE(d1.resolved_cases, 0) AS resolved_cases_1,
+  COALESCE(d2.resolved_cases, 0) AS resolved_cases_2,
+  (COALESCE(d2.resolved_cases,0) - COALESCE(d1.resolved_cases,0)) AS resolved_cases_delta,
+  CASE WHEN COALESCE(d1.resolved_cases,0) = 0 THEN NULL ELSE ((COALESCE(d2.resolved_cases,0) - COALESCE(d1.resolved_cases,0))::numeric / COALESCE(d1.resolved_cases,0)) * 100 END AS resolved_cases_pct_change
+FROM d1
+FULL OUTER JOIN d2 USING (period, branch_id, product_type)
+ORDER BY period, branch_id, product_type;
+$$;
+
+-- =========================
+-- Drill-down detail views for cards
+-- =========================
+DROP VIEW IF EXISTS kastle_banking.vw_sales_detail CASCADE;
+CREATE VIEW kastle_banking.vw_sales_detail AS
+SELECT 
+  t.transaction_id,
+  t.transaction_date,
+  t.account_number,
+  a.customer_id,
+  t.debit_credit,
+  t.transaction_amount,
+  t.narration,
+  t.channel,
+  t.status,
+  COALESCE(t.branch_id, a.branch_id) AS branch_id,
+  a.product_id
+FROM kastle_banking.transactions t
+LEFT JOIN kastle_banking.accounts a
+  ON a.account_number::text = t.account_number::text;
+
+DROP VIEW IF EXISTS kastle_banking.vw_collections_detail CASCADE;
+CREATE VIEW kastle_banking.vw_collections_detail AS
+SELECT 
+  d.summary_date,
+  d.branch_id,
+  d.total_due_amount,
+  d.total_collected,
+  d.collection_rate,
+  d.accounts_due,
+  d.accounts_collected,
+  d.ptps_obtained,
+  d.ptps_kept,
+  d.digital_payments
+FROM kastle_banking.daily_collection_summary d;
+
+DROP VIEW IF EXISTS kastle_banking.vw_customers_detail CASCADE;
+CREATE VIEW kastle_banking.vw_customers_detail AS
+SELECT 
+  c.customer_id,
+  c.full_name,
+  c.onboarding_date,
+  COALESCE(c.onboarding_branch, NULLIF(c.branch_id, '')::varchar(10)) AS branch_id,
+  c.customer_type,
+  c.customer_segment AS segment,
+  c.customer_status,
+  c.risk_category
+FROM kastle_banking.customers c;
+
+DROP VIEW IF EXISTS kastle_banking.vw_accounts_detail CASCADE;
+CREATE VIEW kastle_banking.vw_accounts_detail AS
+SELECT 
+  a.account_id,
+  a.account_number,
+  a.customer_id,
+  a.product_id,
+  a.branch_id,
+  a.opening_date,
+  a.account_status,
+  a.current_balance
+FROM kastle_banking.accounts a;
+
+DROP VIEW IF EXISTS kastle_banking.vw_cases_detail CASCADE;
+CREATE VIEW kastle_banking.vw_cases_detail AS
+SELECT 
+  cc.case_id,
+  cc.case_number,
+  cc.customer_id,
+  cc.account_number,
+  cc.branch_id,
+  cc.product_type,
+  cc.total_outstanding,
+  cc.total_overdue,
+  cc.days_past_due AS dpd,
+  cc.case_status,
+  cc.assigned_to,
+  cc.assignment_date,
+  cc.created_at,
+  cc.updated_at
+FROM kastle_banking.collection_cases cc;

--- a/setup_comparison_dashboard.sql
+++ b/setup_comparison_dashboard.sql
@@ -201,8 +201,8 @@ $$;
 -- 1) Sales comparison
 DROP FUNCTION IF EXISTS kastle_banking.fn_compare_sales(text[], integer[], date, date, date, date, text) CASCADE;
 CREATE FUNCTION kastle_banking.fn_compare_sales(
-  p_branch_ids text[] DEFAULT NULL,
-  p_product_ids integer[] DEFAULT NULL,
+  p_branch_ids text[],
+  p_product_ids integer[],
   p_start_1 date,
   p_end_1 date,
   p_start_2 date,
@@ -257,7 +257,7 @@ $$;
 -- 2) Collections comparison
 DROP FUNCTION IF EXISTS kastle_banking.fn_compare_collections(text[], date, date, date, date, text) CASCADE;
 CREATE FUNCTION kastle_banking.fn_compare_collections(
-  p_branch_ids text[] DEFAULT NULL,
+  p_branch_ids text[],
   p_start_1 date,
   p_end_1 date,
   p_start_2 date,
@@ -306,7 +306,7 @@ $$;
 -- 3) Customers comparison (new customers)
 DROP FUNCTION IF EXISTS kastle_banking.fn_compare_customers(text[], date, date, date, date, text) CASCADE;
 CREATE FUNCTION kastle_banking.fn_compare_customers(
-  p_branch_ids text[] DEFAULT NULL,
+  p_branch_ids text[],
   p_start_1 date,
   p_end_1 date,
   p_start_2 date,
@@ -355,8 +355,8 @@ $$;
 -- 4) Accounts (Products) comparison (new accounts)
 DROP FUNCTION IF EXISTS kastle_banking.fn_compare_accounts(text[], integer[], date, date, date, date, text) CASCADE;
 CREATE FUNCTION kastle_banking.fn_compare_accounts(
-  p_branch_ids text[] DEFAULT NULL,
-  p_product_ids integer[] DEFAULT NULL,
+  p_branch_ids text[],
+  p_product_ids integer[],
   p_start_1 date,
   p_end_1 date,
   p_start_2 date,
@@ -411,8 +411,8 @@ $$;
 -- 5) Cases comparison (by product_type text)
 DROP FUNCTION IF EXISTS kastle_banking.fn_compare_cases(text[], text[], date, date, date, date, text) CASCADE;
 CREATE FUNCTION kastle_banking.fn_compare_cases(
-  p_branch_ids text[] DEFAULT NULL,
-  p_product_types text[] DEFAULT NULL,
+  p_branch_ids text[],
+  p_product_types text[],
   p_start_1 date,
   p_end_1 date,
   p_start_2 date,

--- a/setup_comparison_dashboard.sql
+++ b/setup_comparison_dashboard.sql
@@ -178,6 +178,16 @@ AS $$
   END;
 $$;
 
+-- Also provide a public shim so unqualified calls to period_bucket() work
+DROP FUNCTION IF EXISTS public.period_bucket(date, text) CASCADE;
+CREATE FUNCTION public.period_bucket(p_date date, p_granularity text)
+RETURNS date
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT kastle_banking.period_bucket(p_date, p_granularity);
+$$;
+
 -- =========================
 -- Generic comparison helper to compute delta and pct change
 -- =========================

--- a/setup_comparison_dashboard.sql
+++ b/setup_comparison_dashboard.sql
@@ -8,6 +8,47 @@
 -- =========================
 -- Sales (Transactions) Daily View
 -- =========================
+-- Create a portable source view for transactions depending on what exists
+DO $$
+BEGIN
+  IF to_regclass('kastle_banking.transactions') IS NOT NULL THEN
+    EXECUTE 'CREATE OR REPLACE VIEW kastle_banking.vw_tx_source AS SELECT * FROM kastle_banking.transactions';
+  ELSIF to_regclass('kastle_banking.transactions_view') IS NOT NULL THEN
+    EXECUTE 'CREATE OR REPLACE VIEW kastle_banking.vw_tx_source AS SELECT * FROM kastle_banking.transactions_view';
+  ELSIF to_regclass('public.transactions') IS NOT NULL THEN
+    EXECUTE 'CREATE OR REPLACE VIEW kastle_banking.vw_tx_source AS SELECT * FROM public.transactions';
+  ELSE
+    EXECUTE 'CREATE OR REPLACE VIEW kastle_banking.vw_tx_source AS 
+      SELECT 
+        NULL::bigint AS transaction_id,
+        now()::timestamptz AS transaction_date,
+        NULL::varchar AS account_number,
+        NULL::int AS transaction_type_id,
+        NULL::varchar AS debit_credit,
+        0::numeric(18,2) AS transaction_amount,
+        NULL::varchar AS currency_code,
+        NULL::numeric AS running_balance,
+        NULL::varchar AS contra_account,
+        NULL::varchar AS channel,
+        NULL::varchar AS reference_number,
+        NULL::varchar AS cheque_number,
+        NULL::text AS narration,
+        NULL::varchar AS beneficiary_name,
+        NULL::varchar AS beneficiary_account,
+        NULL::varchar AS beneficiary_bank,
+        NULL::varchar AS status,
+        NULL::varchar AS approval_status,
+        NULL::varchar AS approved_by,
+        NULL::varchar AS reversal_ref,
+        NULL::varchar AS branch_id,
+        NULL::varchar AS teller_id,
+        NULL::varchar AS device_id,
+        NULL::varchar AS ip_address,
+        now()::timestamptz AS created_at,
+        now()::timestamptz AS posted_at';
+  END IF;
+END $$;
+
 DROP VIEW IF EXISTS kastle_banking.vw_sales_daily CASCADE;
 CREATE VIEW kastle_banking.vw_sales_daily AS
 WITH tx AS (
@@ -18,7 +59,7 @@ WITH tx AS (
     t.debit_credit,
     t.status,
     t.transaction_amount::numeric(18,2) AS amount
-  FROM kastle_banking.transactions t
+  FROM kastle_banking.vw_tx_source t
   LEFT JOIN kastle_banking.accounts a
     ON a.account_number::text = t.account_number::text
 )

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,6 +58,7 @@ import DashboardDetailNew from './pages/DashboardDetailNew';
 import ModernDashboardDetail from './pages/ModernDashboardDetail';
 import DashboardCardsDemo from './pages/DashboardCardsDemo';
 import DashboardReports from './pages/DashboardReports';
+const ComparisonDashboardLazy = React.lazy(() => import('./pages/ComparisonDashboard'));
 import ReportsHealthCheck from './pages/ReportsHealthCheck';
 import TestDashboardRouting from './pages/TestDashboardRouting';
 import TestDashboardDetailNew from './pages/TestDashboardDetailNew';
@@ -77,6 +78,7 @@ import OverdueAmountDetail from './pages/details/OverdueAmountDetail';
 import { EnhancedCustomDashboard } from '@/components/dashboard/EnhancedCustomDashboard';
 
 import { Toaster } from './components/ui/sonner';
+
 import { useTranslation } from 'react-i18next';
 
 import 'react-grid-layout/css/styles.css';
@@ -313,6 +315,7 @@ function AppContent() {
           <Route path="/dashboard/detail/:type/:widgetId" element={<DashboardDetail />} />
           <Route path="/dashboard/detail-new/:section/:widgetId" element={<DashboardDetailNew />} />
           <Route path="/dashboard/modern-detail/:cardType" element={<ModernDashboardDetail />} />
+          <Route path="/dashboard/comparison" element={<React.Suspense fallback={null}> <ComparisonDashboardLazy /> </React.Suspense>} />
           {/* Dedicated card detail pages */}
           <Route path="/dashboard/total-assets" element={<TotalAssetsDetail />} />
           <Route path="/dashboard/performance-indicators" element={<PerformanceIndicatorsDetail />} />

--- a/src/pages/ComparisonDashboard.jsx
+++ b/src/pages/ComparisonDashboard.jsx
@@ -1,0 +1,170 @@
+import React, { useMemo, useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { DateRange } from 'react-day-picker';
+import { ComparisonService } from '@/services/comparisonService';
+import { useNavigate } from 'react-router-dom';
+import { format } from 'date-fns';
+import { MultiSelect } from '@/components/ui/multi-select';
+import { supabase } from '@/lib/supabase';
+
+function useDefaultRanges() {
+  const today = new Date();
+  const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+  const endOfMonth = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+  const prevStart = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+  const prevEnd = new Date(today.getFullYear(), today.getMonth(), 0);
+  return {
+    range1: { from: startOfMonth, to: endOfMonth },
+    range2: { from: prevStart, to: prevEnd }
+  };
+}
+
+function formatNumber(x) {
+  if (x == null) return '-';
+  return new Intl.NumberFormat().format(x);
+}
+
+function Delta({ delta, pct }) {
+  const up = (pct || 0) > 0;
+  const color = pct == null ? '#64748b' : up ? '#16a34a' : '#dc2626';
+  return (
+    <div style={{ color, fontSize: 12 }}>
+      {delta == null ? '-' : `${formatNumber(delta)} (${pct?.toFixed?.(1)}%)`}
+    </div>
+  );
+}
+
+export default function ComparisonDashboard() {
+  const { range1, range2 } = useDefaultRanges();
+  const [date1, setDate1] = useState(range1);
+  const [date2, setDate2] = useState(range2);
+  const [granularity, setGranularity] = useState('month');
+  const [selectedBranches, setSelectedBranches] = useState([]);
+  const [selectedProducts, setSelectedProducts] = useState([]);
+  const [selectedCaseProducts, setSelectedCaseProducts] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [data, setData] = useState({});
+  const navigate = useNavigate();
+  const [branchOptions, setBranchOptions] = useState([]);
+  const [productOptions, setProductOptions] = useState([]);
+  const [caseProductOptions, setCaseProductOptions] = useState([]);
+
+  useEffect(() => {
+    (async () => {
+      const [{ data: branches }, { data: products }, { data: caseProducts }] = await Promise.all([
+        supabase.from('branches').select('branch_id, branch_name').limit(500),
+        supabase.from('products').select('product_id, product_name').limit(500),
+        supabase.from('collection_cases').select('product_type').not('product_type', 'is', null).limit(500)
+      ]);
+      setBranchOptions((branches || []).map(b => ({ value: b.branch_id, label: `${b.branch_id} - ${b.branch_name}` })));
+      setProductOptions((products || []).map(p => ({ value: p.product_id, label: p.product_name })));
+      const uniqTypes = Array.from(new Set((caseProducts || []).map(c => c.product_type).filter(Boolean)));
+      setCaseProductOptions(uniqTypes.map(v => ({ value: v, label: v })));
+    })();
+  }, []);
+
+  const load = async () => {
+    setLoading(true);
+    try {
+      const [sales, collections, customers, accounts, cases] = await Promise.all([
+        ComparisonService.compareSales({ branchIds: selectedBranches.length ? selectedBranches : null, productIds: selectedProducts.length ? selectedProducts : null, start1: date1.from, end1: date1.to, start2: date2.from, end2: date2.to, granularity }),
+        ComparisonService.compareCollections({ branchIds: selectedBranches.length ? selectedBranches : null, start1: date1.from, end1: date1.to, start2: date2.from, end2: date2.to, granularity }),
+        ComparisonService.compareCustomers({ branchIds: selectedBranches.length ? selectedBranches : null, start1: date1.from, end1: date1.to, start2: date2.from, end2: date2.to, granularity }),
+        ComparisonService.compareAccounts({ branchIds: selectedBranches.length ? selectedBranches : null, productIds: selectedProducts.length ? selectedProducts : null, start1: date1.from, end1: date1.to, start2: date2.from, end2: date2.to, granularity }),
+        ComparisonService.compareCases({ branchIds: selectedBranches.length ? selectedBranches : null, productTypes: selectedCaseProducts.length ? selectedCaseProducts : null, start1: date1.from, end1: date1.to, start2: date2.from, end2: date2.to, granularity })
+      ]);
+      setData({ sales, collections, customers, accounts, cases });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const cards = useMemo(() => {
+    const sAgg = (data.sales?.data || []).reduce((acc, r) => ({
+      v1: acc.v1 + Number(r.value_1 || 0),
+      v2: acc.v2 + Number(r.value_2 || 0)
+    }), { v1: 0, v2: 0 });
+    const sDelta = sAgg.v2 - sAgg.v1;
+    const sPct = sAgg.v1 ? (sDelta / sAgg.v1) * 100 : null;
+
+    const cAgg = (data.collections?.data || []).reduce((acc, r) => ({
+      v1: acc.v1 + Number(r.value_1 || 0),
+      v2: acc.v2 + Number(r.value_2 || 0)
+    }), { v1: 0, v2: 0 });
+    const cDelta = cAgg.v2 - cAgg.v1;
+    const cPct = cAgg.v1 ? (cDelta / cAgg.v1) * 100 : null;
+
+    const cuAgg = (data.customers?.data || []).reduce((acc, r) => ({
+      v1: acc.v1 + Number(r.value_1 || 0),
+      v2: acc.v2 + Number(r.value_2 || 0)
+    }), { v1: 0, v2: 0 });
+    const cuDelta = cuAgg.v2 - cuAgg.v1;
+    const cuPct = cuAgg.v1 ? (cuDelta / cuAgg.v1) * 100 : null;
+
+    const aAgg = (data.accounts?.data || []).reduce((acc, r) => ({
+      v1: acc.v1 + Number(r.value_1 || 0),
+      v2: acc.v2 + Number(r.value_2 || 0)
+    }), { v1: 0, v2: 0 });
+    const aDelta = aAgg.v2 - aAgg.v1;
+    const aPct = aAgg.v1 ? (aDelta / aAgg.v1) * 100 : null;
+
+    const caAgg = (data.cases?.data || []).reduce((acc, r) => ({
+      v1: acc.v1 + Number(r.new_cases_1 || 0),
+      v2: acc.v2 + Number(r.new_cases_2 || 0)
+    }), { v1: 0, v2: 0 });
+    const caDelta = caAgg.v2 - caAgg.v1;
+    const caPct = caAgg.v1 ? (caDelta / caAgg.v1) * 100 : null;
+
+    return [
+      { key: 'sales', title: 'Sales (Credits)', value: sAgg.v2, delta: sDelta, pct: sPct, onClick: () => navigate('/dashboard/modern-detail/sales') },
+      { key: 'collections', title: 'Collections', value: cAgg.v2, delta: cDelta, pct: cPct, onClick: () => navigate('/collection/daily') },
+      { key: 'customers', title: 'New Customers', value: cuAgg.v2, delta: cuDelta, pct: cuPct, onClick: () => navigate('/dashboard/customer-growth') },
+      { key: 'accounts', title: 'New Accounts', value: aAgg.v2, delta: aDelta, pct: aPct, onClick: () => navigate('/accounts') },
+      { key: 'cases', title: 'New Cases', value: caAgg.v2, delta: caDelta, pct: caPct, onClick: () => navigate('/collection/cases') }
+    ];
+  }, [data, navigate]);
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="flex flex-wrap gap-2 items-center">
+        <Select value={granularity} onValueChange={setGranularity}>
+          <SelectTrigger className="w-[160px]"><SelectValue placeholder="Granularity" /></SelectTrigger>
+          <SelectContent>
+            <SelectItem value="day">Day</SelectItem>
+            <SelectItem value="month">Month</SelectItem>
+            <SelectItem value="quarter">Quarter</SelectItem>
+            <SelectItem value="year">Year</SelectItem>
+          </SelectContent>
+        </Select>
+        <MultiSelect options={branchOptions} value={selectedBranches} onChange={setSelectedBranches} placeholder="Branches" className="w-[240px]" />
+        <MultiSelect options={productOptions} value={selectedProducts} onChange={setSelectedProducts} placeholder="Products" className="w-[240px]" />
+        <MultiSelect options={caseProductOptions} value={selectedCaseProducts} onChange={setSelectedCaseProducts} placeholder="Case Products" className="w-[240px]" />
+        <Button variant="outline" onClick={load} disabled={loading}>Refresh</Button>
+        <div className="text-sm text-muted-foreground">
+          {format(date1.from, 'yyyy-MM-dd')} → {format(date1.to, 'yyyy-MM-dd')} vs {format(date2.from, 'yyyy-MM-dd')} → {format(date2.to, 'yyyy-MM-dd')}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-4">
+        {cards.map((c) => (
+          <Card key={c.key} className="cursor-pointer" onClick={c.onClick}>
+            <CardHeader>
+              <CardTitle className="text-sm text-muted-foreground">{c.title}</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="text-2xl font-semibold">{formatNumber(c.value)}</div>
+              <Delta delta={c.delta} pct={c.pct} />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/services/comparisonService.js
+++ b/src/services/comparisonService.js
@@ -10,8 +10,8 @@ function toDateString(d) {
 export const ComparisonService = {
   async compareSales({ branchIds = null, productIds = null, start1, end1, start2, end2, granularity = 'month' }) {
     const { data, error } = await supabase.rpc('fn_compare_sales', {
-      p_branch_ids: branchIds,
-      p_product_ids: productIds,
+      p_branch_ids: branchIds || null,
+      p_product_ids: productIds || null,
       p_start_1: toDateString(start1),
       p_end_1: toDateString(end1),
       p_start_2: toDateString(start2),
@@ -23,7 +23,7 @@ export const ComparisonService = {
 
   async compareCollections({ branchIds = null, start1, end1, start2, end2, granularity = 'month' }) {
     const { data, error } = await supabase.rpc('fn_compare_collections', {
-      p_branch_ids: branchIds,
+      p_branch_ids: branchIds || null,
       p_start_1: toDateString(start1),
       p_end_1: toDateString(end1),
       p_start_2: toDateString(start2),
@@ -35,7 +35,7 @@ export const ComparisonService = {
 
   async compareCustomers({ branchIds = null, start1, end1, start2, end2, granularity = 'month' }) {
     const { data, error } = await supabase.rpc('fn_compare_customers', {
-      p_branch_ids: branchIds,
+      p_branch_ids: branchIds || null,
       p_start_1: toDateString(start1),
       p_end_1: toDateString(end1),
       p_start_2: toDateString(start2),
@@ -47,8 +47,8 @@ export const ComparisonService = {
 
   async compareAccounts({ branchIds = null, productIds = null, start1, end1, start2, end2, granularity = 'month' }) {
     const { data, error } = await supabase.rpc('fn_compare_accounts', {
-      p_branch_ids: branchIds,
-      p_product_ids: productIds,
+      p_branch_ids: branchIds || null,
+      p_product_ids: productIds || null,
       p_start_1: toDateString(start1),
       p_end_1: toDateString(end1),
       p_start_2: toDateString(start2),
@@ -60,8 +60,8 @@ export const ComparisonService = {
 
   async compareCases({ branchIds = null, productTypes = null, start1, end1, start2, end2, granularity = 'month' }) {
     const { data, error } = await supabase.rpc('fn_compare_cases', {
-      p_branch_ids: branchIds,
-      p_product_types: productTypes,
+      p_branch_ids: branchIds || null,
+      p_product_types: productTypes || null,
       p_start_1: toDateString(start1),
       p_end_1: toDateString(end1),
       p_start_2: toDateString(start2),

--- a/src/services/comparisonService.js
+++ b/src/services/comparisonService.js
@@ -1,0 +1,116 @@
+import { supabase } from '@/lib/supabase';
+import { formatApiResponse } from '@/utils/apiHelpers';
+
+function toDateString(d) {
+  if (!d) return null;
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return date.toISOString().slice(0, 10);
+}
+
+export const ComparisonService = {
+  async compareSales({ branchIds = null, productIds = null, start1, end1, start2, end2, granularity = 'month' }) {
+    const { data, error } = await supabase.rpc('fn_compare_sales', {
+      p_branch_ids: branchIds,
+      p_product_ids: productIds,
+      p_start_1: toDateString(start1),
+      p_end_1: toDateString(end1),
+      p_start_2: toDateString(start2),
+      p_end_2: toDateString(end2),
+      p_granularity: granularity
+    });
+    return formatApiResponse(data, error);
+  },
+
+  async compareCollections({ branchIds = null, start1, end1, start2, end2, granularity = 'month' }) {
+    const { data, error } = await supabase.rpc('fn_compare_collections', {
+      p_branch_ids: branchIds,
+      p_start_1: toDateString(start1),
+      p_end_1: toDateString(end1),
+      p_start_2: toDateString(start2),
+      p_end_2: toDateString(end2),
+      p_granularity: granularity
+    });
+    return formatApiResponse(data, error);
+  },
+
+  async compareCustomers({ branchIds = null, start1, end1, start2, end2, granularity = 'month' }) {
+    const { data, error } = await supabase.rpc('fn_compare_customers', {
+      p_branch_ids: branchIds,
+      p_start_1: toDateString(start1),
+      p_end_1: toDateString(end1),
+      p_start_2: toDateString(start2),
+      p_end_2: toDateString(end2),
+      p_granularity: granularity
+    });
+    return formatApiResponse(data, error);
+  },
+
+  async compareAccounts({ branchIds = null, productIds = null, start1, end1, start2, end2, granularity = 'month' }) {
+    const { data, error } = await supabase.rpc('fn_compare_accounts', {
+      p_branch_ids: branchIds,
+      p_product_ids: productIds,
+      p_start_1: toDateString(start1),
+      p_end_1: toDateString(end1),
+      p_start_2: toDateString(start2),
+      p_end_2: toDateString(end2),
+      p_granularity: granularity
+    });
+    return formatApiResponse(data, error);
+  },
+
+  async compareCases({ branchIds = null, productTypes = null, start1, end1, start2, end2, granularity = 'month' }) {
+    const { data, error } = await supabase.rpc('fn_compare_cases', {
+      p_branch_ids: branchIds,
+      p_product_types: productTypes,
+      p_start_1: toDateString(start1),
+      p_end_1: toDateString(end1),
+      p_start_2: toDateString(start2),
+      p_end_2: toDateString(end2),
+      p_granularity: granularity
+    });
+    return formatApiResponse(data, error);
+  },
+
+  async getSalesDetails(filters) {
+    const { branchIds = null, productIds = null, start, end } = filters;
+    let q = supabase.from('vw_sales_detail').select('*').gte('transaction_date', toDateString(start)).lte('transaction_date', toDateString(end));
+    if (branchIds && branchIds.length) q = q.in('branch_id', branchIds);
+    if (productIds && productIds.length) q = q.in('product_id', productIds);
+    const { data, error } = await q.limit(1000);
+    return formatApiResponse(data, error);
+  },
+
+  async getCollectionsDetails(filters) {
+    const { branchIds = null, start, end } = filters;
+    let q = supabase.from('vw_collections_detail').select('*').gte('summary_date', toDateString(start)).lte('summary_date', toDateString(end));
+    if (branchIds && branchIds.length) q = q.in('branch_id', branchIds);
+    const { data, error } = await q.limit(1000);
+    return formatApiResponse(data, error);
+  },
+
+  async getCustomersDetails(filters) {
+    const { branchIds = null, start, end } = filters;
+    let q = supabase.from('vw_customers_detail').select('*').gte('onboarding_date', toDateString(start)).lte('onboarding_date', toDateString(end));
+    if (branchIds && branchIds.length) q = q.in('branch_id', branchIds);
+    const { data, error } = await q.limit(1000);
+    return formatApiResponse(data, error);
+  },
+
+  async getAccountsDetails(filters) {
+    const { branchIds = null, productIds = null, start, end } = filters;
+    let q = supabase.from('vw_accounts_detail').select('*').gte('opening_date', toDateString(start)).lte('opening_date', toDateString(end));
+    if (branchIds && branchIds.length) q = q.in('branch_id', branchIds);
+    if (productIds && productIds.length) q = q.in('product_id', productIds);
+    const { data, error } = await q.limit(1000);
+    return formatApiResponse(data, error);
+  },
+
+  async getCasesDetails(filters) {
+    const { branchIds = null, productTypes = null, start, end } = filters;
+    let q = supabase.from('vw_cases_detail').select('*').gte('created_at', toDateString(start)).lte('created_at', toDateString(end));
+    if (branchIds && branchIds.length) q = q.in('branch_id', branchIds);
+    if (productTypes && productTypes.length) q = q.in('product_type', productTypes);
+    const { data, error } = await q.limit(1000);
+    return formatApiResponse(data, error);
+  }
+};


### PR DESCRIPTION
Adds a comparison dashboard to analyze key business metrics (sales, collections, customers, accounts, cases) across two user-defined periods with filtering capabilities.

This includes new SQL views and functions for daily aggregation and period-over-period comparison, a frontend service to interact with these functions, and a new React UI page at `/dashboard/comparison` for interactive filtering and display. Drill-down to existing detail pages is supported.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e7b6ec7-e83c-421b-b5a3-f6d07a03df2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e7b6ec7-e83c-421b-b5a3-f6d07a03df2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

