### PR TITLE
Fix dashboard view button after save

### DIFF
--- a/DASHBOARD_VIEW_BUTTON_FIX.md
+++ b/DASHBOARD_VIEW_BUTTON_FIX.md
@@ -1,0 +1,65 @@
+# Dashboard View Button Fix
+
+## Issue
+After customizing and saving the dashboard, users were unable to find the "View" button to switch from edit mode to view mode. This made it difficult to see the dashboard in its final state after making changes.
+
+## Solution Implemented
+
+### 1. **Added Clear View Dashboard Button**
+- Added a prominent "View Dashboard" button that appears when in edit mode
+- The button is clearly visible alongside the Save button
+- Uses the Eye icon for better visual recognition
+
+### 2. **Automatic Mode Switching After Save**
+- Dashboard automatically switches to view mode after saving
+- Shows a toast notification confirming the save and mode switch
+- Refreshes data to show the saved configuration
+
+### 3. **Improved Edit/View Mode Toggle**
+- Added an "Edit Dashboard" button that appears in view mode
+- Clear visual feedback with badges showing current mode (Edit Mode/View Mode)
+- Toast notifications when switching between modes
+
+### 4. **Files Modified**
+
+#### `/src/pages/Dashboard.jsx`
+- Added automatic switch to view mode after saving
+- Added "View Dashboard" button in edit mode
+- Added "Edit Dashboard" button in view mode
+- Added toast notifications for mode changes
+
+#### `/src/pages/CustomDashboard.jsx`
+- Added automatic switch to view mode after saving
+- Added "View Dashboard" button in edit mode
+- Added "Edit Dashboard" button in view mode
+- Added visual badge showing current mode
+- Added toast notifications for mode changes
+
+#### `/src/components/dashboard/EnhancedCustomDashboard.jsx`
+- Added automatic switch to view mode after saving
+- Added "View Dashboard" button in edit mode
+- Added "Edit Dashboard" button in view mode
+- Added toast notifications for mode changes
+
+## User Experience Improvements
+
+1. **Clear Visual Feedback**: Users can now easily see which mode they're in (Edit vs View)
+2. **Intuitive Workflow**: After saving, the dashboard automatically switches to view mode
+3. **Easy Mode Switching**: Prominent buttons make it easy to switch between modes
+4. **Consistent Behavior**: All dashboard components now have the same behavior
+
+## Testing
+
+To test the changes:
+1. Navigate to the Dashboard page
+2. Click "Edit Dashboard" to enter edit mode
+3. Make changes to the dashboard
+4. Click "Save Dashboard" - the dashboard should automatically switch to view mode
+5. The "View Dashboard" button should be visible while in edit mode
+6. The "Edit Dashboard" button should be visible while in view mode
+
+## Notes
+
+- The changes maintain backward compatibility with existing dashboard configurations
+- All dashboard components (Dashboard, CustomDashboard, EnhancedCustomDashboard) have been updated for consistency
+- Toast notifications provide clear feedback about mode changes and save operations

--- a/src/components/dashboard/EnhancedCustomDashboard.jsx
+++ b/src/components/dashboard/EnhancedCustomDashboard.jsx
@@ -422,7 +422,10 @@ export function EnhancedCustomDashboard() {
     localStorage.setItem('osol_custom_dashboard', JSON.stringify(dashboardConfig));
     setLastSaved(new Date());
     
-    toast.success("Dashboard Saved: Your dashboard configuration has been saved successfully");
+    toast.success("Dashboard Saved: Your dashboard configuration has been saved successfully. Switching to view mode...");
+    
+    // Automatically switch to view mode after saving
+    setIsEditMode(false);
   }, [dashboardName, selectedTemplate, layouts, widgets, colorTheme, autoRefresh, refreshInterval, showGridLines, compactMode]);
 
   // Load saved dashboard
@@ -644,25 +647,53 @@ export function EnhancedCustomDashboard() {
               Export
             </Button>
             
-            <Button
-              size="sm"
-              onClick={saveDashboard}
-            >
-              <Save className="w-4 h-4 mr-2" />
-              Save Dashboard
-            </Button>
+            {isEditMode ? (
+              <>
+                <Button
+                  size="sm"
+                  onClick={saveDashboard}
+                >
+                  <Save className="w-4 h-4 mr-2" />
+                  Save Dashboard
+                </Button>
+                
+                <Button
+                  size="sm"
+                  variant="default"
+                  onClick={() => {
+                    setIsEditMode(false);
+                    toast.info('Switched to view mode');
+                  }}
+                >
+                  <Eye className="w-4 h-4 mr-2" />
+                  View Dashboard
+                </Button>
 
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => {
-                setTemplateName(dashboardName || 'Custom Template');
-                setShowSaveTemplate(true);
-              }}
-            >
-              <Sparkles className="w-4 h-4 mr-2" />
-              Save as Template
-            </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => {
+                    setTemplateName(dashboardName || 'Custom Template');
+                    setShowSaveTemplate(true);
+                  }}
+                >
+                  <Sparkles className="w-4 h-4 mr-2" />
+                  Save as Template
+                </Button>
+              </>
+            ) : (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setIsEditMode(true);
+                  toast.info('Switched to edit mode');
+                }}
+              >
+                <Settings className="w-4 h-4 mr-2" />
+                Edit Dashboard
+              </Button>
+            )}
           </div>
         </div>
 

--- a/src/pages/CustomDashboard.jsx
+++ b/src/pages/CustomDashboard.jsx
@@ -498,7 +498,14 @@ export function CustomDashboard() {
         }
       }
 
-      toast.success('Dashboard saved successfully');
+      toast.success('Dashboard saved successfully! Switching to view mode...');
+      
+      // Automatically switch to view mode after saving
+      setIsEditMode(false);
+      
+      // Refresh data to show the saved dashboard
+      await fetchDashboardData();
+      
     } catch (error) {
       console.error('Error saving dashboard:', error);
       toast.error('Failed to save dashboard');
@@ -1097,13 +1104,40 @@ export function CustomDashboard() {
             <RefreshCw className={`h-4 w-4 mr-2 ${refreshing ? 'animate-spin' : ''}`} />
             Refresh
           </Button>
-          <Button
-            size="sm"
-            onClick={saveDashboardConfiguration}
-          >
-            <Save className="h-4 w-4 mr-2" />
-            Save Dashboard
-          </Button>
+          {isEditMode ? (
+            <>
+              <Button
+                size="sm"
+                onClick={saveDashboardConfiguration}
+              >
+                <Save className="h-4 w-4 mr-2" />
+                Save Dashboard
+              </Button>
+              <Button
+                size="sm"
+                variant="default"
+                onClick={() => {
+                  setIsEditMode(false);
+                  toast.info('Switched to view mode');
+                }}
+              >
+                <Eye className="h-4 w-4 mr-2" />
+                View Dashboard
+              </Button>
+            </>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                setIsEditMode(true);
+                toast.info('Switched to edit mode');
+              }}
+            >
+              <Settings className="h-4 w-4 mr-2" />
+              Edit Dashboard
+            </Button>
+          )}
         </div>
       </div>
 
@@ -1116,15 +1150,27 @@ export function CustomDashboard() {
               <CardDescription>Choose a template or build your own custom dashboard</CardDescription>
             </div>
             <div className="flex items-center gap-2">
+              <Badge variant={isEditMode ? "default" : "secondary"} className="px-3 py-1">
+                {isEditMode ? (
+                  <>
+                    <Unlock className="w-3 h-3 mr-1" />
+                    Edit Mode
+                  </>
+                ) : (
+                  <>
+                    <Lock className="w-3 h-3 mr-1" />
+                    View Mode
+                  </>
+                )}
+              </Badge>
               <Switch
                 id="edit-mode"
                 checked={isEditMode}
-                onCheckedChange={setIsEditMode}
+                onCheckedChange={(checked) => {
+                  setIsEditMode(checked);
+                  toast.info(checked ? 'Switched to edit mode' : 'Switched to view mode');
+                }}
               />
-              <Label htmlFor="edit-mode" className="cursor-pointer">
-                {isEditMode ? <Unlock className="w-4 h-4" /> : <Lock className="w-4 h-4" />}
-                {isEditMode ? t('dashboard.editMode') : t('dashboard.viewMode')}
-              </Label>
             </div>
           </div>
         </CardHeader>

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -2561,7 +2561,14 @@ export default function EnhancedDashboard() {
         }
       }
       
-      toast.success('Dashboard saved successfully');
+      toast.success('Dashboard saved successfully! Switching to view mode...');
+      
+      // Automatically switch to view mode after saving
+      setIsEditMode(false);
+      
+      // Refresh data to show the saved dashboard
+      await fetchDashboardData();
+      
     } catch (error) {
       console.error('Error saving dashboard:', error);
       toast.error('Failed to save dashboard');
@@ -3155,13 +3162,13 @@ export default function EnhancedDashboard() {
               </Label>
             </div>
             
-            {isEditMode && (
+            {isEditMode ? (
               <>
                 <Button
                   size="sm"
                   onClick={() => setShowTemplates(true)}
                 >
-                                      <Layers className={cn("h-4 w-4", rtl.marginEnd(2))} />
+                  <Layers className={cn("h-4 w-4", rtl.marginEnd(2))} />
                   Templates
                 </Button>
                 
@@ -3169,18 +3176,42 @@ export default function EnhancedDashboard() {
                   size="sm"
                   onClick={saveDashboardConfig}
                 >
-                                      <Save className={cn("h-4 w-4", rtl.marginEnd(2))} />
+                  <Save className={cn("h-4 w-4", rtl.marginEnd(2))} />
                   Save
                 </Button>
+                
+                <Button
+                  size="sm"
+                  variant="default"
+                  onClick={() => {
+                    setIsEditMode(false);
+                    toast.info('Switched to view mode');
+                  }}
+                >
+                  <Eye className={cn("h-4 w-4", rtl.marginEnd(2))} />
+                  View Dashboard
+                </Button>
 
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={() => navigate('/dashboard/custom')}
-                  >
-                    Customize
-                  </Button>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={() => navigate('/dashboard/custom')}
+                >
+                  Customize
+                </Button>
               </>
+            ) : (
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => {
+                  setIsEditMode(true);
+                  toast.info('Switched to edit mode');
+                }}
+              >
+                <Settings className={cn("h-4 w-4", rtl.marginEnd(2))} />
+                Edit Dashboard
+              </Button>
             )}
             
             <DropdownMenu>


### PR DESCRIPTION
Improve dashboard customization workflow by adding clear view/edit mode buttons and automatically switching to view mode after saving.

Previously, users found it unintuitive to switch from edit to view mode after saving dashboard changes. This PR addresses that by providing prominent buttons and an automatic transition, enhancing the user experience across `Dashboard.jsx`, `CustomDashboard.jsx`, and `EnhancedCustomDashboard.jsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-79d18f40-3bb1-4d88-8f65-6f768884d3cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79d18f40-3bb1-4d88-8f65-6f768884d3cc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

